### PR TITLE
chore: renovate to batch, and not update docker nor ory-client

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["ory-client"],
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["docker"],
+      "enabled": false
+    },
+    {
+      "groupName": "dependencies-non-major",
+      "matchUpdateTypes": ["digest", "minor", "patch", "pin"]
+    }
   ]
 }


### PR DESCRIPTION
The ory-client is needed for tests, their latest version is quite broken and they are not willing to fix it. So we pin the dependency.

The docker tag updates here are just annoying busywork with no real benefit.

The cargo updates should come in one big PR.