### PR TITLE
chore: disable renovate lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchPackageNames": ["ory-client"],
@@ -15,6 +18,11 @@
       "groupName": "extension-dependencies-non-major",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "addLabels": ["extension-version-bump-needed"]
+    },
+    {
+      "matchFiles": ["Cargo.lock"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Let's disable the renovate lock file maintenance. It should just update the Cargo.toml files in the extensions directory, which then trigger extension version upgrades.