### PR TITLE
fix(gb-9068): replace newlines with long base64 cursors

### DIFF
--- a/crates/sql-ast/src/ast/function.rs
+++ b/crates/sql-ast/src/ast/function.rs
@@ -17,6 +17,7 @@ mod json_unquote;
 mod lower;
 mod maximum;
 mod minimum;
+mod replace;
 mod row_number;
 mod row_to_json;
 mod sum;
@@ -43,6 +44,7 @@ pub use json_unquote::*;
 pub use lower::*;
 pub use maximum::*;
 pub use minimum::*;
+pub use replace::*;
 pub use row_number::*;
 pub use row_to_json::*;
 pub use sum::*;
@@ -99,6 +101,7 @@ pub(crate) enum FunctionType<'a> {
     RowNumber(RowNumber<'a>),
     Decode(Decode<'a>),
     ConvertFrom(ConvertFrom<'a>),
+    Replace(Replace<'a>),
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {

--- a/crates/sql-ast/src/ast/function/replace.rs
+++ b/crates/sql-ast/src/ast/function/replace.rs
@@ -1,0 +1,51 @@
+use super::Function; // Assuming 'super::Function' is accessible
+use crate::ast::{Expression, FunctionType}; // Assuming these paths are correct
+
+/// Represents the nature of a string to be used in SQL,
+/// particularly for functions like REPLACE where escaping might differ.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SqlStringPattern<'a> {
+    /// A literal string. During SQL rendering, this will typically be enclosed in single quotes,
+    /// with internal single quotes escaped (e.g., 'a literal string', 'O''Malley').
+    Literal(&'a str),
+    /// A string whose content should be interpreted using PostgreSQL's E'' escape syntax.
+    /// The provided string is the raw content (e.g., "\n", "foo\\bar").
+    /// The SQL renderer will wrap this content appropriately (e.g., E'\n', E'foo\\\\bar').
+    EscapedContent(&'a str),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Replace<'a> {
+    pub(crate) expression: Box<Expression<'a>>,
+    pub(crate) old_value: SqlStringPattern<'a>,
+    pub(crate) new_value: &'a str,
+}
+
+/// Constructs a `REPLACE` function AST node.
+///
+/// # Arguments
+/// * `expression` - The base string expression.
+/// * `old_value` - The pattern to search for, represented by `SqlStringPattern`.
+///   This allows specifying either a literal string or content for E'' escaping.
+/// * `new_value` - The literal string to replace with.
+pub fn replace<'a, E>(expression: E, old_value: SqlStringPattern<'a>, new_value: &'a str) -> Function<'a>
+where
+    E: Into<Expression<'a>>,
+{
+    let fun = Replace {
+        expression: Box::new(expression.into()),
+        old_value,
+        new_value,
+    };
+
+    fun.into()
+}
+
+impl<'a> From<Replace<'a>> for Function<'a> {
+    fn from(value: Replace<'a>) -> Self {
+        Self {
+            r#type: FunctionType::Replace(value),
+            alias: None,
+        }
+    }
+}

--- a/extensions/postgres/extension.toml
+++ b/extensions/postgres/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "postgres"
-version = "0.4.3"
+version = "0.4.4"
 description = """
 Integrate your Postgres database directly into Grafbase Gateway. This extension exposes your database schema and with the help of the introspection tool, automatically generates a fully-functional GraphQL subgraph, eliminating the need to build and maintain a separate service.
 """

--- a/extensions/postgres/src/resolve/query/select/pagination.rs
+++ b/extensions/postgres/src/resolve/query/select/pagination.rs
@@ -11,8 +11,9 @@ use grafbase_database_definition::TableColumnWalker;
 use grafbase_sdk::{SdkError, host_io::postgres::types::DatabaseType};
 use sql_ast::ast::{
     Aliasable, Column, CommonTableExpression, Comparable, ConditionTree, EncodeFormat, Expression, Function, Joinable,
-    Order, OrderDefinition, Ordering, Select, Table, asterisk, cast, coalesce, convert_from, count, decode, encode,
-    json_agg, json_build_array, json_build_object, json_extract_array_elem, raw, row_number, row_to_json,
+    Order, OrderDefinition, Ordering, Select, SqlStringPattern, Table, asterisk, cast, coalesce, convert_from, count,
+    decode, encode, json_agg, json_build_array, json_build_object, json_extract_array_elem, raw, replace, row_number,
+    row_to_json,
 };
 
 /// The name of the Common Table Expression (CTE) that contains the decoded cursor.
@@ -166,8 +167,10 @@ fn build_filtered_cte<'a>(builder: &SelectBuilder<'a>, args: &CollectionArgs<'a>
         let generated_cursor_expr = encode(
             cast(cast(json_build_array(cursor_payload_expressions), "text"), "bytea"),
             EncodeFormat::Base64,
-        )
-        .alias("cursor");
+        );
+
+        let generated_cursor_expr =
+            replace(generated_cursor_expr, SqlStringPattern::EscapedContent("\\n"), "").alias("cursor");
 
         select.value(generated_cursor_expr);
     }

--- a/extensions/postgres/tests/lookup_many/mod.rs
+++ b/extensions/postgres/tests/lookup_many/mod.rs
@@ -505,98 +505,98 @@ async fn with_composite_key() {
     "#);
 }
 
-// TODO: there's a bug in the engine making this test to fail, enable again when fixed
-// #[tokio::test]
-// async fn with_one_missing_from_the_middle() {
-//     let mock_sdl = indoc! {r#"
-//         extend schema
-//             @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+#[tokio::test]
+async fn with_one_missing_from_the_middle() {
+    let mock_sdl = indoc! {r#"
+        extend schema
+            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
 
-//         type User @key(fields: "id") {
-//           id: Int!
-//           age: Int!
-//         }
+        type User @key(fields: "id") {
+          id: Int!
+          age: Int!
+        }
 
-//         type Query {
-//           userFoobar: [User!]!
-//         }
-//     "#};
+        type Query {
+          userFoobar: [User!]!
+        }
+    "#};
 
-//     let response = json!([
-//         {
-//             "id": 3,
-//             "age": 13
-//         },
-//         {
-//             "id": 2,
-//             "age": 14
-//         },
-//         {
-//             "id": 1,
-//             "age": 12
-//         }
-//     ]);
+    let response = json!([
+        {
+            "id": 3,
+            "age": 13
+        },
+        {
+            "id": 2,
+            "age": 14
+        },
+        {
+            "id": 1,
+            "age": 12
+        }
+    ]);
 
-//     let subgraph = DynamicSchema::builder(mock_sdl)
-//         .with_resolver("Query", "userFoobar", response)
-//         .into_subgraph("mock")
-//         .unwrap();
+    let subgraph = DynamicSchema::builder(mock_sdl)
+        .with_resolver("Query", "userFoobar", response)
+        .into_subgraph("mock")
+        .unwrap();
 
-//     let api = PgTestApi::new_with_subgraphs("", vec![subgraph], |api| async move {
-//         let schema = indoc! {r#"
-//             CREATE TABLE "User" (
-//                 id INT PRIMARY KEY NOT NULL,
-//                 name VARCHAR(255) NOT NULL
-//             )
-//         "#};
+    let api = PgTestApi::new_with_subgraphs("", vec![subgraph], |api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY NOT NULL,
+                name VARCHAR(255) NULL
+            )
+        "#};
 
-//         api.execute_sql(schema).await;
+        api.execute_sql(schema).await;
 
-//         let insert = indoc! {r#"
-//             INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (3, 'Pentti')
-//         "#};
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (3, 'Pentti')
+        "#};
 
-//         api.execute_sql(insert).await;
-//     })
-//     .await;
+        api.execute_sql(insert).await;
+    })
+    .await;
 
-//     let runner = api.runner_spawn().await;
+    let runner = api.runner_spawn().await;
 
-//     let query = indoc! {r"
-//         query {
-//           userFoobar {
-//             id
-//             name
-//             age
-//           }
-//         }
-//     "};
+    let query = indoc! {r"
+        query {
+          userFoobar {
+            id
+            name
+            age
+          }
+        }
+    "};
 
-//     let response = runner.graphql_query::<serde_json::Value>(query).send().await.unwrap();
+    let response = runner.graphql_query::<serde_json::Value>(query).send().await.unwrap();
 
-//     insta::assert_json_snapshot!(response, @r#"
-//     {
-//       "data": {
-//         "userFoobar": [
-//           {
-//             "id": 3,
-//             "name": "Pentti",
-//             "age": 13
-//           },
-//           {
-//             "id": 2,
-//             "age": 14
-//           },
-//           {
-//             "id": 1,
-//             "name": "Musti",
-//             "age": 12
-//           }
-//         ]
-//       }
-//     }
-//     "#);
-// }
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "userFoobar": [
+          {
+            "id": 3,
+            "name": "Pentti",
+            "age": 13
+          },
+          {
+            "id": 2,
+            "name": null,
+            "age": 14
+          },
+          {
+            "id": 1,
+            "name": "Musti",
+            "age": 12
+          }
+        ]
+      }
+    }
+    "#);
+}
 
 #[tokio::test]
 async fn lookup_rename() {

--- a/extensions/requires-scopes/tests/integration_tests.rs
+++ b/extensions/requires-scopes/tests/integration_tests.rs
@@ -104,36 +104,6 @@ async fn anonymous_token() {
           "extensions": {
             "code": "UNAUTHORIZED"
           }
-        },
-        {
-          "message": "Not authorized",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadAndWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized",
-          "locations": [
-            {
-              "line": 5,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadOrWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
         }
       ]
     }
@@ -175,36 +145,6 @@ async fn token_without_scopes() {
           "extensions": {
             "code": "UNAUTHORIZED"
           }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadAndWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 5,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadOrWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
         }
       ]
     }
@@ -242,36 +182,6 @@ async fn token_with_insufficient_scopes() {
           ],
           "path": [
             "hasReadScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadAndWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 5,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadOrWriteScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"
@@ -354,21 +264,6 @@ async fn token_with_write_scope() {
           ],
           "path": [
             "hasReadScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadAndWriteScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"


### PR DESCRIPTION
So, seems like base64 encoding in postgres inserts newlines every 76 characters. That kind of breaks things and is not cool, so let's not do that.