### PR TITLE
fix(gb-9069): fix ordering for next/prev cursors if moving backwards

### DIFF
--- a/crates/sql-ast/src/ast/ordering.rs
+++ b/crates/sql-ast/src/ast/ordering.rs
@@ -40,10 +40,8 @@ impl Order {
         match self {
             Order::Asc => Order::Desc,
             Order::Desc => Order::Asc,
-            Order::AscNullsFirst => Order::DescNullsFirst,
-            Order::AscNullsLast => Order::DescNullsLast,
-            Order::DescNullsFirst => Order::AscNullsFirst,
-            Order::DescNullsLast => Order::AscNullsLast,
+            Order::AscNullsFirst | Order::AscNullsLast => Order::DescNullsLast,
+            Order::DescNullsFirst | Order::DescNullsLast => Order::AscNullsFirst,
         }
     }
 

--- a/extensions/postgres/extension.toml
+++ b/extensions/postgres/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "postgres"
-version = "0.4.4"
+version = "0.4.5"
 description = """
 Integrate your Postgres database directly into Grafbase Gateway. This extension exposes your database schema and with the help of the introspection tool, automatically generates a fully-functional GraphQL subgraph, eliminating the need to build and maintain a separate service.
 """


### PR DESCRIPTION
So what was broken was in pagination:

- move forward N steps, start/end cursors are correct
- move backwards N steps, now the start/end cursors were flipped

This was very visible when I tested with a real client. Added a test for this case, and "simplified" the ordering a bit.