### PR TITLE
fix(gb-9072): fix a naming issue in pagination filters

### DIFF
--- a/extensions/postgres/extension.toml
+++ b/extensions/postgres/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "postgres"
-version = "0.4.5"
+version = "0.4.6"
 description = """
 Integrate your Postgres database directly into Grafbase Gateway. This extension exposes your database schema and with the help of the introspection tool, automatically generates a fully-functional GraphQL subgraph, eliminating the need to build and maintain a separate service.
 """

--- a/extensions/postgres/src/context/filter/complex.rs
+++ b/extensions/postgres/src/context/filter/complex.rs
@@ -136,7 +136,7 @@ fn generate_conditions(
     let mut compares = Vec::with_capacity(operations.len());
 
     for (key, value) in operations {
-        let table_column = (column.table().database_name(), column.database_name());
+        let table_column = (column.table().client_name(), column.database_name());
 
         let expression = |value| {
             let db_value = DatabaseValue::from_json_input(value, column.database_type(), column.is_array())?;

--- a/extensions/postgres/tests/find_many/mod.rs
+++ b/extensions/postgres/tests/find_many/mod.rs
@@ -63,7 +63,7 @@ async fn everything() {
 async fn eq_pk() {
     let api = PgTestApi::new("", |api| async move {
         let schema = indoc! {r#"
-            CREATE TABLE "User" (
+            CREATE TABLE "users" (
                 id INT PRIMARY KEY,
                 name VARCHAR(255) NOT NULL
             )
@@ -72,7 +72,7 @@ async fn eq_pk() {
         api.execute_sql(schema).await;
 
         let insert = indoc! {r#"
-            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+            INSERT INTO "users" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
         "#};
 
         api.execute_sql(insert).await;


### PR DESCRIPTION
So basically this generated a faulty query. Now we have at least one test where the table is users and the type is User, and we don't crash anymore.