### PR TITLE
fix(gb-9075): do not generate cursors if not needed

### DIFF
--- a/extensions/postgres/README.md
+++ b/extensions/postgres/README.md
@@ -262,6 +262,16 @@ type Mutation {
 *   **Returning Data:** All mutations support a `returning` selection set, allowing you to fetch data about the affected rows within the same database transaction.
 *   **Performance:** Each mutation executes as a single SQL statement.
 
+### Logging
+
+The extension logs parameterized queries at the debug level without revealing any user data.
+
+Enable query logging by setting the environment variable:
+
+```bash
+GRAFBASE_LOG=info,postgres=debug
+```
+
 ### Supported Postgres Versions
 
 We primarily test against the latest stable Postgres version. The extension relies on SQL features, particularly JSON/JSONB functions, available in Postgres. Therefore, the minimum supported version is **Postgres 9.4**.

--- a/extensions/postgres/extension.toml
+++ b/extensions/postgres/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "postgres"
-version = "0.4.6"
+version = "0.4.7"
 description = """
 Integrate your Postgres database directly into Grafbase Gateway. This extension exposes your database schema and with the help of the introspection tool, automatically generates a fully-functional GraphQL subgraph, eliminating the need to build and maintain a separate service.
 """


### PR DESCRIPTION
This avoids encoding a cursor for every row if the user only selects the start/end cursors in the page info.