### PR TITLE
postgres-introspection: fix typo in composite-schemas spec url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-postgres"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022ad47e4f2a198381e26ef6d22139935d784a4254d0cedabd6396052a1c3b2b"
+checksum = "ef3e0e124bcee37434056131a0d00e150f556446fc3e655abd54c08ef626f921"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -1862,9 +1862,9 @@ checksum = "ebfd7fd1a0e3427f3e6c9ef7bc4e0d2f05c9e94ecf859176cdf297212fe8f06e"
 
 [[package]]
 name = "graphql-composition"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec3d30dc261df686cc46e212279e71a3e1b4de4f007dbc131db304dd621762"
+checksum = "58d6cc2b721f76a5dc608fefa610b3740d4c9d547eba3ffa8e79670a5dd73ed4"
 dependencies = [
  "bitflags 2.9.0",
  "cynic-parser",
@@ -1878,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "graphql-federated-graph"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1acf641b57dacf508edbe21df9a23744d2d40d010a4c51b0902d374aa1019c"
+checksum = "7a04f965bbdf9037c41808615d9a9f743440c89c8ded5c328a8df8aad5eebef6"
 dependencies = [
  "bitflags 2.9.0",
  "cynic-parser",
@@ -2764,7 +2764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3646,7 +3646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3666,7 +3666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",

--- a/cli/postgres/Cargo.toml
+++ b/cli/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-postgres"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/cli/postgres/grafbase-postgres.toml
+++ b/cli/postgres/grafbase-postgres.toml
@@ -1,0 +1,1 @@
+extension_url = "http://example.com/gbpg"

--- a/crates/postgres-introspection/src/render/schema_directives.rs
+++ b/crates/postgres-introspection/src/render/schema_directives.rs
@@ -54,7 +54,7 @@ pub fn render<'a>(database_definition: &'a DatabaseDefinition, extension_url: &'
 
         directive.push_argument(Argument::string(
             "url",
-            "https://specs.grafbase.com/composite-schema/v1",
+            "https://specs.grafbase.com/composite-schemas/v1",
         ));
 
         directive.push_argument(Argument::new(

--- a/extensions/postgres/tests/introspection/configuration.rs
+++ b/extensions/postgres/tests/introspection/configuration.rs
@@ -63,7 +63,7 @@ async fn globally_disabled_mutations() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -517,7 +517,7 @@ async fn globally_disabled_queries() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -1098,7 +1098,7 @@ async fn disable_mutations_per_schema() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -1722,7 +1722,7 @@ async fn disable_queries_per_schema() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -2441,7 +2441,7 @@ async fn disable_mutations_per_table() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -3394,7 +3394,7 @@ async fn disable_queries_per_table() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -4428,7 +4428,7 @@ async fn schema_mutations_setting_takes_precedence_over_global_setting() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -5054,7 +5054,7 @@ async fn schema_queries_setting_takes_precedence_over_global_setting() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -5767,7 +5767,7 @@ async fn table_mutations_setting_takes_precedence_over_global_setting() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -6393,7 +6393,7 @@ async fn table_queries_setting_takes_precedence_over_global_setting() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -7117,7 +7117,7 @@ async fn table_mutations_setting_takes_precedence_over_schema_setting() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -8075,7 +8075,7 @@ async fn table_queries_setting_takes_precedence_over_schema_setting() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -9125,7 +9125,7 @@ async fn disable_queries_globally_for_views() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -9734,7 +9734,7 @@ async fn disable_queries_per_view() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"

--- a/extensions/postgres/tests/introspection/mod.rs
+++ b/extensions/postgres/tests/introspection/mod.rs
@@ -49,7 +49,7 @@ async fn table_with_generated_always_identity_primary_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -518,7 +518,7 @@ async fn table_with_generated_by_default_identity_primary_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -1019,7 +1019,7 @@ async fn table_with_serial_primary_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -1527,7 +1527,7 @@ async fn table_with_enum_field() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -2107,7 +2107,7 @@ async fn table_with_int_primary_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -2608,7 +2608,7 @@ async fn table_with_int_unique() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -3110,7 +3110,7 @@ async fn table_with_serial_primary_key_string_unique() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -3700,7 +3700,7 @@ async fn table_with_composite_primary_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -4234,7 +4234,7 @@ async fn two_schemas_same_table_name() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -5063,7 +5063,7 @@ async fn table_with_an_array_column() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -5658,7 +5658,7 @@ async fn table_with_jsonb_column() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -6258,7 +6258,7 @@ async fn table_with_json_column() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -6870,7 +6870,7 @@ async fn two_tables_with_single_column_foreign_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -7885,7 +7885,7 @@ async fn foreign_key_to_a_table_without_a_key_should_not_create_a_relation() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -8397,7 +8397,7 @@ async fn issue_november_2023() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -9459,7 +9459,7 @@ async fn table_with_comment() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -9970,7 +9970,7 @@ async fn table_with_commented_column() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -10564,7 +10564,7 @@ async fn enum_with_comment() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -11164,7 +11164,7 @@ async fn table_with_commented_foreign_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"

--- a/extensions/postgres/tests/introspection/views.rs
+++ b/extensions/postgres/tests/introspection/views.rs
@@ -61,7 +61,7 @@ async fn view_with_int_unique() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -714,7 +714,7 @@ async fn materialized_view_with_int_unique() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -1376,7 +1376,7 @@ async fn view_with_composite_key() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -2089,7 +2089,7 @@ async fn view_with_relation_from_view_to_table() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"
@@ -3153,7 +3153,7 @@ async fn view_with_relation_from_table_to_view() {
         ]
       )
       @link(
-        url: "https://specs.grafbase.com/composite-schema/v1",
+        url: "https://specs.grafbase.com/composite-schemas/v1",
         import: [
           "@lookup",
           "@key"

--- a/extensions/postgres/tests/lookup_many/mod.rs
+++ b/extensions/postgres/tests/lookup_many/mod.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 async fn lookup_int_pk() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "id") {
           id: Int!
@@ -89,7 +89,7 @@ async fn lookup_int_pk() {
 async fn lookup_unique_string() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "email") {
           email: String!
@@ -171,7 +171,7 @@ async fn lookup_unique_string() {
 async fn with_one_to_many_join() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "id") {
           id: Int!
@@ -293,7 +293,7 @@ async fn with_one_to_many_join() {
 async fn with_one_to_many_join_renamed() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "id") {
           id: Int!
@@ -415,7 +415,7 @@ async fn with_one_to_many_join_renamed() {
 async fn with_composite_key() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "name email") {
           name: String!
@@ -509,7 +509,7 @@ async fn with_composite_key() {
 async fn with_one_missing_from_the_middle() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "id") {
           id: Int!
@@ -602,7 +602,7 @@ async fn with_one_missing_from_the_middle() {
 async fn lookup_rename() {
     let mock_sdl = indoc! {r#"
         extend schema
-            @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+            @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
 
         type User @key(fields: "id") {
           id: Int!


### PR DESCRIPTION
It's "composite-schemas" (plural). Composition and the engine assume that url.