### PR TITLE
chore: Improved test setup

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,8 +55,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - gateway: "0.39.0"
-            cli: "0.96.0"
+          - gateway: "0.40.0"
+            cli: "0.96.3"
     env:
       RUSTFLAGS: -D warnings
     steps:

--- a/test-matrix/src/main.rs
+++ b/test-matrix/src/main.rs
@@ -23,6 +23,11 @@ fn main() -> anyhow::Result<()> {
 
         let cargo_toml = cargo_toml::parse(&cargo_toml)?;
 
+        println!("\n** {} **", cargo_toml.name());
+        duct::cmd("grafbase", ["extension", "build", "--debug"])
+            .dir(path)
+            .run()?;
+
         test_arguments.push("-p".to_string());
         test_arguments.push(cargo_toml.name().to_string());
 
@@ -33,7 +38,11 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    duct::cmd("cargo", &test_arguments).run()?;
+    println!("\n** Running tests **");
+    duct::cmd("cargo", &test_arguments)
+        .env("LOCAL_EXTENSION_WASM_CACHE", "1")
+        .env("PREBUILT_EXTENSION", "1")
+        .run()?;
 
     Ok(())
 }


### PR DESCRIPTION
Compiling all extensions once before starting the tests and using the `LOCAL_EXTENSION_WASM_CACHE` function to speed up a bit tests. Not relevant in the CI yet as it'll be part of `0.41` but already super useful locally.