### PR TITLE
Add www-authenticate extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6809,6 +6809,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "www-authenticate"
+version = "0.1.0"
+dependencies = [
+ "grafbase-sdk",
+ "insta",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/extensions/www-authenticate/.gitignore
+++ b/extensions/www-authenticate/.gitignore
@@ -1,0 +1,3 @@
+target
+build
+.build.lock

--- a/extensions/www-authenticate/Cargo.toml
+++ b/extensions/www-authenticate/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "www-authenticate"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+grafbase-sdk.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+grafbase-sdk.workspace = true
+insta.workspace = true
+serde_json.workspace = true
+tokio.workspace = true

--- a/extensions/www-authenticate/README.md
+++ b/extensions/www-authenticate/README.md
@@ -1,0 +1,19 @@
+# WWW-Authenticate extension
+
+This is a very simple hook extension for the Grafbase Gateway that inserts the `WWW-Authenticate` header into all responses with status code Unauthorized (401).
+
+The [`WWW-Authenticate` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) is used to provide information on the authentication process to clients after a failed request. It is a [general HTTP concept](https://httpwg.org/specs/rfc9110.html#field.www-authenticate), and notably useful if you want to make the Gateway act as an [OAuth 2.1 protected resource](https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response), for example when exposing a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/specification/draft/basic/authorization) server.
+
+## Usage
+
+Add this to your configuration:
+
+```toml
+[extensions]
+www-authenticate.version = "0.1"
+
+[extensions.www-authenticate.config]
+www_authenticate_header_value = """Bearer resource_metadata="https://api.grafbase.com/.well-known/oauth-protected-resource""""
+```
+
+The value of `www_authenticate_header_value` will be used as the value of the `WWW-Authenticate` header in all responses with status code Unauthorized (401).

--- a/extensions/www-authenticate/extension.toml
+++ b/extensions/www-authenticate/extension.toml
@@ -1,0 +1,16 @@
+[extension]
+name = "www-authenticate"
+version = "0.1.0"
+type = "hooks"
+description = "Inject the WWW-Authenticate header on 401 responses"
+repository_url = "https://github.com/grafbase/extensions/tree/main/extensions/www-authenticate"
+license = "Apache-2.0"
+
+# These are the default permissions for the extension.
+# The user can enable or disable them as needed in the gateway
+# configuration file.
+[permissions]
+network = false
+stdout = false
+stderr = false
+environment_variables = false

--- a/extensions/www-authenticate/src/lib.rs
+++ b/extensions/www-authenticate/src/lib.rs
@@ -1,0 +1,41 @@
+use grafbase_sdk::{
+    HooksExtension,
+    host_io::event_queue::EventQueue,
+    host_io::http::{Method, StatusCode},
+    types::{Configuration, Error, ErrorResponse, GatewayHeaders},
+};
+
+#[derive(HooksExtension)]
+struct WwwAuthenticate {
+    config: WwwAuthenticateConfig,
+}
+
+#[derive(serde::Deserialize)]
+struct WwwAuthenticateConfig {
+    www_authenticate_header_value: String,
+}
+
+impl HooksExtension for WwwAuthenticate {
+    fn new(config: Configuration) -> Result<Self, Error> {
+        let config = config.deserialize()?;
+
+        Ok(Self { config })
+    }
+
+    fn on_request(&mut self, _url: &str, _method: Method, _headers: &mut GatewayHeaders) -> Result<(), ErrorResponse> {
+        Ok(())
+    }
+
+    fn on_response(
+        &mut self,
+        status: StatusCode,
+        headers: &mut GatewayHeaders,
+        _event_queue: EventQueue,
+    ) -> Result<(), String> {
+        if status == StatusCode::UNAUTHORIZED {
+            headers.append("WWW-Authenticate", &self.config.www_authenticate_header_value);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a very simple hook extension for the Grafbase Gateway that inserts the `WWW-Authenticate` header into all responses with status code Unauthorized (401).

We are going to recommend it in the Grafbase MCP docs, both as an off-the-shelf implementation and as an example for more advanced use cases.