### PR TITLE
jwt: add support for configurable headers on 401

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "duration-str",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-protected-resource"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "grafbase-sdk",
  "insta",

--- a/crates/oauth-protected-resource-shared/src/lib.rs
+++ b/crates/oauth-protected-resource-shared/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 pub struct OAuthConfig {
     /// https://datatracker.ietf.org/doc/html/rfc9728#name-obtaining-protected-resourc
     #[serde(default = "default_path")]
-    pub path: String,
+    pub metadata_path: String,
     pub metadata: Metadata,
 }
 

--- a/extensions/jwt/CHANGELOG.md
+++ b/extensions/jwt/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2025-07-15
+
+- Added support for static headers returned with 401 responses.
+- Renamed the `[extensions.jwt.config.oauth]` section of the configuration to `[extensions.jwt.config.oauth.protected_resource.metadata]`.
+
 ## [1.2.0] - 2025-06-25
 
 - Added support for [OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) and returning the `WWW-Authenticate` header on unsuccessful authentication. See the README for the new configuration options.

--- a/extensions/jwt/Cargo.toml
+++ b/extensions/jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/extensions/jwt/README.md
+++ b/extensions/jwt/README.md
@@ -50,12 +50,17 @@ poll_interval = 60
 # cookie_name = "my-cookie"
 
 # Optional - OAuth Protected Resource Metadata configuration (RFC 9728)
-# [extensions.jwt.config.oauth]
-# path = "/.well-known/oauth-protected-resource"  # Optional custom path
-# [extensions.jwt.config.oauth.metadata]
+# [extensions.jwt.config.oauth.protected_resource]
+# metadata_path = "/.well-known/oauth-protected-resource"  # Optional custom path
+# [extensions.jwt.config.oauth.protected_resource.metadata]
 # resource = "https://api.example.com"  # Required to enable the metadata endpoint
 # authorization_servers = ["https://auth.example.com"]
 # scopes_supported = ["read", "write"]
+
+# Optional - Static headers that are returned with 401 Unauthorized responses
+# [[extensions.jwt.config.unauthenticated_headers]]
+# name = "WWW-Authenticate"
+# value = 'Bearer realm="grafbase", error="invalid_token", error_description="Invalid JWT token" resource_metadata="https://api.grafbase.com/.well-known/oauth-protected-resource"'
 ```
 
 If neither a header nor a cookie is specified, the extension will default to the following:
@@ -80,11 +85,11 @@ default = "anonymous"
 
 The JWT extension can optionally expose an OAuth Protected Resource Metadata endpoint according to [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). This allows OAuth clients to discover information about your protected resource.
 
-To enable this feature, add the `oauth.metadata.resource` configuration inside your extension configuration:
+To enable this feature, add the `oauth.protected_resource.metadata.resource` configuration inside your extension configuration:
 
 ```toml
 # grafbase.toml
-[extensions.jwt.config.oauth.metadata]
+[extensions.jwt.config.oauth.protected_resource.metadata]
 resource = "https://api.example.com"  # Required to enable the metadata endpoint
 ```
 
@@ -104,11 +109,11 @@ This extension validates JWT ([RFC 7519](https://datatracker.ietf.org/doc/html/r
 
 The JWT extension can optionally expose an OAuth Protected Resource Metadata endpoint according to [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). This allows OAuth clients to discover information about your protected resource.
 
-To enable this feature, add the `oauth.metadata.resource` configuration inside your extension configuration:
+To enable this feature, add the `oauth.protected_resource.metadata.resource` configuration inside your extension configuration:
 
 ```toml
 # grafbase.toml
-[extensions.jwt.config.oauth.metadata]
+[extensions.jwt.config.oauth.protected_resource.metadata]
 resource = "https://api.example.com"  # Required to enable the metadata endpoint
 ```
 
@@ -118,9 +123,9 @@ resource = "https://api.example.com"  # Required to enable the metadata endpoint
 # grafbase.toml
 [extensions.jwt.config.oauth]
 # Optional - Override the default path (defaults to "/.well-known/oauth-protected-resource")
-path = "/.well-known/oauth-protected-resource"
+metadata_path = "/.well-known/oauth-protected-resource"
 
-[extensions.jwt.config.oauth.metadata]
+[extensions.jwt.config.oauth.protected_resource.metadata]
 # Required - The resource identifier URL for this protected resource
 resource = "https://api.example.com"
 
@@ -146,4 +151,4 @@ resource_tos_uri = "https://example.com/api/terms"
 tls_client_certificate_bound_access_tokens = true
 ```
 
-When this feature is enabled, the JWT extension will serve the OAuth Protected Resource Metadata at the configured path (defaulting to `/.well-known/oauth-protected-resource`). This eliminates the need to install the separate `oauth-protected-resource` extension if you're already using JWT authentication.
+When at least the resource is defined, the JWT extension will serve the OAuth Protected Resource Metadata at the configured path (defaulting to `/.well-known/oauth-protected-resource`). This eliminates the need to install the separate `oauth-protected-resource` extension if you're already using JWT authentication.

--- a/extensions/jwt/src/config.rs
+++ b/extensions/jwt/src/config.rs
@@ -1,5 +1,4 @@
 use duration_str::deserialize_duration;
-use oauth_protected_resource_shared::OAuthConfig;
 use std::time::Duration;
 use url::Url;
 
@@ -11,6 +10,20 @@ pub(crate) struct Config {
     pub audience: Option<Vec<String>>,
     pub locations: Vec<Location>,
     pub oauth: Option<OAuthConfig>,
+    pub unauthenticated_headers: Vec<StaticHeader>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OAuthConfig {
+    pub protected_resource: oauth_protected_resource_shared::OAuthConfig,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StaticHeader {
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Debug)]
@@ -33,6 +46,7 @@ impl<'de> serde::Deserialize<'de> for Config {
             header_value_prefix,
             cookie_name,
             oauth,
+            unauthenticated_headers,
         } = TomlConfig::deserialize(deserializer)?;
         let mut locations = Vec::new();
         if let Some(header_name) = header_name {
@@ -57,6 +71,7 @@ impl<'de> serde::Deserialize<'de> for Config {
             audience,
             locations,
             oauth,
+            unauthenticated_headers,
         })
     }
 }
@@ -76,6 +91,8 @@ struct TomlConfig {
     cookie_name: Option<String>,
     #[serde(default)]
     oauth: Option<OAuthConfig>,
+    #[serde(default)]
+    unauthenticated_headers: Vec<StaticHeader>,
 }
 
 fn default_poll_interval() -> Duration {

--- a/extensions/jwt/tests/integration_tests.rs
+++ b/extensions/jwt/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 mod hydra;
 mod oauth_metadata_tests;
+mod unauthenticated_headers_tests;
 
 use std::collections::HashMap;
 

--- a/extensions/jwt/tests/oauth_metadata_tests/mod.rs
+++ b/extensions/jwt/tests/oauth_metadata_tests/mod.rs
@@ -24,7 +24,7 @@ async fn test_just_resource() {
             [extensions.jwt.config]
             url = "{JWKS_URI}"
 
-            [extensions.jwt.config.oauth.metadata]
+            [extensions.jwt.config.oauth.protected_resource.metadata]
             resource = "https://protected.example.com"
         "#})
         .build()
@@ -80,10 +80,10 @@ async fn test_custom_path() {
             [extensions.jwt.config]
             url = "{JWKS_URI}"
 
-            [extensions.jwt.config.oauth]
-            path = "/custom-oauth-metadata"
+            [extensions.jwt.config.oauth.protected_resource]
+            metadata_path = "/custom-oauth-metadata"
 
-            [extensions.jwt.config.oauth.metadata]
+            [extensions.jwt.config.oauth.protected_resource.metadata]
             resource = "https://protected.example.com"
         "#})
         .build()
@@ -126,7 +126,7 @@ async fn test_jwks_uri_default() {
             [extensions.jwt.config]
             url = "{JWKS_URI}"
 
-            [extensions.jwt.config.oauth.metadata]
+            [extensions.jwt.config.oauth.protected_resource.metadata]
             resource = "https://protected.example.com"
         "#})
         .build()
@@ -154,7 +154,7 @@ async fn test_all_metadata() {
         .toml_config(formatdoc! {r#"
             [extensions.jwt.config]
             url = "{JWKS_URI}"
-            [extensions.jwt.config.oauth.metadata]
+            [extensions.jwt.config.oauth.protected_resource.metadata]
             resource = "https://protected.example.com"
             authorization_servers = ["https://auth.example.com"]
             jwks_uri = "https://auth.example.com/.well-known/jwks.json"
@@ -235,7 +235,7 @@ async fn test_metadata_with_authentication() {
             [extensions.jwt.config]
             url = "{JWKS_URI}"
 
-            [extensions.jwt.config.oauth.metadata]
+            [extensions.jwt.config.oauth.protected_resource.metadata]
             resource = "https://protected.example.com"
         "#})
         .build()

--- a/extensions/jwt/tests/unauthenticated_headers_tests/mod.rs
+++ b/extensions/jwt/tests/unauthenticated_headers_tests/mod.rs
@@ -1,0 +1,32 @@
+use super::*;
+use reqwest::StatusCode;
+
+#[tokio::test]
+async fn test_unauthenticated_headers() {
+    let gateway = gateway_builder()
+        .toml_config(formatdoc! {r#"
+            [extensions.jwt.config]
+            url = "{JWKS_URI}"
+
+            [[extensions.jwt.config.unauthenticated_headers]]
+            name = "Www-Authenticate"
+            value = "Bearer realm=\"hydra\", error=\"invalid_token\", error_description=\"The token is invalid\""
+        "#})
+        .build()
+        .await
+        .unwrap();
+
+    let response = gateway.query("query { hi }").send().await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let header = response
+        .headers()
+        .get("www-authenticate")
+        .expect("WWW-Authenticate header should be returned");
+
+    assert_eq!(
+        header,
+        "Bearer realm=\"hydra\", error=\"invalid_token\", error_description=\"The token is invalid\""
+    )
+}

--- a/extensions/oauth-protected-resource/Cargo.toml
+++ b/extensions/oauth-protected-resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-protected-resource"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/extensions/oauth-protected-resource/src/lib.rs
+++ b/extensions/oauth-protected-resource/src/lib.rs
@@ -30,7 +30,7 @@ impl AuthenticationExtension for OauthProtectedResourceMetadata {
         response_headers.append("content-type", "application/json");
 
         Ok(vec![
-            PublicMetadataEndpoint::new(config.path.clone(), response_body).with_headers(response_headers),
+            PublicMetadataEndpoint::new(config.metadata_path.clone(), response_body).with_headers(response_headers),
         ])
     }
 }

--- a/extensions/oauth-protected-resource/tests/integration_tests.rs
+++ b/extensions/oauth-protected-resource/tests/integration_tests.rs
@@ -77,7 +77,7 @@ async fn custom_path() {
         .toml_config(
             r#"
             [extensions.oauth-protected-resource.config]
-            path = "/yolo"
+            metadata_path = "/yolo"
             metadata.resource = "https://protected.example.com"
         "#,
         )


### PR DESCRIPTION
And move the `[extensions.jwt.config.oauth]` section of the configuration to `[extensions.jwt.config.oauth.protected_resource.metadata]`.