### PR TITLE
jwt: fix version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.2.0"
+version = "1.3.0"
 dependencies = [
  "base64 0.22.1",
  "duration-str",

--- a/extensions/jwt/CHANGELOG.md
+++ b/extensions/jwt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.0] - 2025-07-15
+## [1.3.0] - 2025-07-15
 
 - Added support for static headers returned with 401 responses.
 - Renamed the `[extensions.jwt.config.oauth]` section of the configuration to `[extensions.jwt.config.oauth.protected_resource.metadata]`.

--- a/extensions/jwt/Cargo.toml
+++ b/extensions/jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt"
-version = "0.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I wrongly updated from 1.2.0 to 0.2.0 in the previous PR. Just confused 1.2.0 with 0.1.2... So let's update to 1.3.0 now.