### PR TITLE
ci: test protoc-gen-grafbase-subgraph

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,3 +94,27 @@ jobs:
           RUSTC_WRAPPER: sccache
         run: |
           cargo run -p test-matrix
+
+      - name: Test protoc-gen-grafbase-subgraph
+        # Will fail if there is nothing to build.
+        continue-on-error: true
+        run: |
+          if [[ "$TARGET_PLATFORM" == "x86_64-unknown-linux-musl" ]]; then
+            protobuf_release_arch="linux-x86_64"
+          elif [[ "$TARGET_PLATFORM" == "aarch64-unknown-linux-musl" ]]; then
+            protobuf_release_arch="linux-aarch_64"
+          elif [[ "$TARGET_PLATFORM" == "aarch64-apple-darwin" ]]; then
+            protobuf_release_arch="osx-aarch_64"
+          fi
+
+          sudo mkdir -p /usr/local/include/google
+          sudo chown -R $USER /usr/local/include/google
+
+          curl -L https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-${protobuf_release_arch}.zip -o protoc.zip
+          unzip protoc.zip -d /usr/local
+          chmod +x /usr/local/bin/protoc
+          rm protoc.zip
+
+          cargo nextest run -p protoc-gen-grafbase-subgraph
+        env:
+          TARGET_PLATFORM: ${{ matrix.platform.target }}


### PR DESCRIPTION
Recently imported, but we can't import the CI logic for tests, pretty different.