### PR TITLE
protoc-gen-grafbase-subgraph: use correct version in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "protoc-gen-grafbase-subgraph"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "indexmap 2.9.0",
  "insta",

--- a/cli/protoc-gen-grafbase-subgraph/Cargo.toml
+++ b/cli/protoc-gen-grafbase-subgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protoc-gen-grafbase-subgraph"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
closes https://linear.app/grafbase/issue/GB-9408/move-protoc-gen-grafbase-subgraph-to-extensions-reo