### PR TITLE
protoc-gen-grafbase-subgraph: allow mapping services to subgraphs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+## General guidelines
+
+- Do not write comments just describing the code. Only write comments describing _why_ that code is written in a certain way, or to point out non-obvious details or caveats. Or to help break up long blocks of code into logical chunks.
+
 ## Rust code conventions
 
 - Always use named interpolation in `format!()` and related invocations. GOOD: `format!("Hello, {name}!")`, BAD: `format!("Hello, {}!", name)`.

--- a/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
+++ b/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+### Added
+
+- **Multiple subgraphs support** added. Support for generating multiple GraphQL files based on service annotations:
+
+  - Services can now have a `subgraph_name` option that maps them to different subgraph files
+  - When any service has a `subgraph_name`, the tool automatically switches to multi-file mode
+  - Generated files are named `<subgraph_name>.graphql` instead of the default `schema.graphql`
+  - Each subgraph file only includes the services and types relevant to that specific subgraph
+  - Multiple services can map to the same subgraph
+  - Subgraph names must match the pattern `[a-zA-Z][a-zA-Z0-9-]*`
+  - Services without `subgraph_name` in multi-file mode are ignored without warning
+
 ### Fixed
 
 - In some scenarios, the plugin would panic because packages were not provided in alphabetical order. This is fixed. (https://github.com/grafbase/extensions/pull/144)

--- a/cli/protoc-gen-grafbase-subgraph/README.md
+++ b/cli/protoc-gen-grafbase-subgraph/README.md
@@ -97,6 +97,49 @@ enum Color {
 }
 ```
 
+### Mapping specific services to different subgraphs
+
+By default, the plugin generates a single `schema.graphql` file containing all services. However, you can map different services to different subgraph files using the `subgraph_name` option:
+
+```protobuf
+import "grafbase/options.proto";
+
+service UserService {
+  option (grafbase.graphql.subgraph_name) = "users";
+
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc CreateUser(CreateUserRequest) returns (User);
+}
+
+service ProductService {
+  option (grafbase.graphql.subgraph_name) = "products";
+
+  rpc GetProduct(GetProductRequest) returns (Product);
+  rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
+}
+
+service OrderService {
+  option (grafbase.graphql.subgraph_name) = "orders";
+
+  rpc CreateOrder(CreateOrderRequest) returns (Order);
+}
+```
+
+This will generate three files:
+- `users.graphql` - Contains only the UserService and its related types
+- `products.graphql` - Contains only the ProductService and its related types
+- `orders.graphql` - Contains only the OrderService and its related types
+
+#### Multi-file mode behavior
+
+- **Automatic mode detection**: As soon as any service has a `subgraph_name` option, the plugin switches to multi-file mode
+- **Service filtering**: Each generated file only includes the services mapped to that subgraph
+- **Type filtering**: Only types actually used by the services in a subgraph are included in that file
+- **Shared subgraphs**: Multiple services can map to the same subgraph by using the same `subgraph_name`
+- **Validation**: Subgraph names must match the pattern `[a-zA-Z][a-zA-Z0-9-]*`
+- **Backward compatibility**: If no services have `subgraph_name`, the default single `schema.graphql` is generated
+- **Services without subgraph_name**: In multi-file mode, services without a `subgraph_name` are ignored
+
 ## Limitations
 
 - Methods with client streaming are supported, but only one message can be sent from the client side.

--- a/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl.rs
@@ -11,15 +11,23 @@ use std::{
 
 const INDENT: &str = "  ";
 
-pub(crate) fn render_graphql_sdl(schema: &GrpcSchema, mut out: impl fmt::Write) -> fmt::Result {
+pub(crate) fn render_graphql_sdl(schema: &GrpcSchema, out: impl fmt::Write) -> fmt::Result {
+    render_graphql_sdl_filtered(schema, None, out)
+}
+
+pub(crate) fn render_graphql_sdl_filtered(
+    schema: &GrpcSchema,
+    service_ids: Option<&[crate::schema::ProtoServiceId]>,
+    mut out: impl fmt::Write,
+) -> fmt::Result {
     out.write_fmt(format_args!(
         "{}",
         crate::display_utils::display_fn(|f| {
-            let types_to_render = services::collect_types_to_render(schema);
+            let types_to_render = services::collect_types_to_render_filtered(schema, service_ids);
 
-            schema_directives::render_schema_directives(schema, &types_to_render, f)?;
+            schema_directives::render_schema_directives_filtered(schema, service_ids, &types_to_render, f)?;
 
-            services::render_services(schema, f)?;
+            services::render_services_filtered(schema, service_ids, f)?;
 
             graphql_types::render_graphql_types(schema, &types_to_render, f)
         })

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
@@ -61,6 +61,7 @@ pub(crate) struct ProtoService {
     pub(crate) description: Option<String>,
     pub(crate) default_to_query_fields: bool,
     pub(crate) default_to_mutation_fields: bool,
+    pub(crate) subgraph_name: Option<String>,
 }
 
 impl ProtoService {

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/view.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/view.rs
@@ -2,6 +2,7 @@ use std::ops::{Deref, Index};
 
 use super::*;
 
+#[derive(Clone, Copy)]
 pub(crate) struct View<'a, Id, Record> {
     pub(crate) id: Id,
     pub(crate) record: &'a Record,

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
@@ -122,6 +122,7 @@ fn translate_service(
         description: location_to_description(location, source_code_info),
         default_to_query_fields: false,
         default_to_mutation_fields: false,
+        subgraph_name: None,
     };
 
     extract_service_graphql_options_from_options(service, &mut proto_service);
@@ -480,8 +481,19 @@ fn extract_service_graphql_options_from_options(service: &ServiceDescriptorProto
         })
         .unwrap_or(false);
 
+    let subgraph_name = service
+        .options
+        .special_fields
+        .unknown_fields()
+        .get(SUBGRAPH_NAME)
+        .and_then(|unknown_value_ref| match unknown_value_ref {
+            protobuf::UnknownValueRef::LengthDelimited(items) => Some(str::from_utf8(items).unwrap().to_owned()),
+            _ => None,
+        });
+
     proto_service.default_to_query_fields = graphql_default_to_query_fields;
     proto_service.default_to_mutation_fields = graphql_default_to_mutation_fields;
+    proto_service.subgraph_name = subgraph_name;
 }
 
 fn extract_method_graphql_options_from_options(

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
@@ -8,7 +8,8 @@ pub(super) const ENUM_DIRECTIVES: u32 = 58301;
 pub(super) const ENUM_VALUE_DIRECTIVES: u32 = 58301;
 
 pub(super) const DEFAULT_TO_QUERY_FIELDS: u32 = 58301;
-pub(super) const DEFAULT_TO_MUTATION_FIELDS: u32 = 58301;
+pub(super) const DEFAULT_TO_MUTATION_FIELDS: u32 = 58302;
+pub(super) const SUBGRAPH_NAME: u32 = 58303;
 
 pub(super) const DIRECTIVES: u32 = 58301;
 pub(super) const IS_QUERY: u32 = 58302;

--- a/cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+++ b/cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
@@ -130,6 +130,11 @@ fn codegen_tests() {
                 }
             }
 
+            // Debug: print what files were generated
+            if test_name.contains("multi") {
+                eprintln!("Generated files for {}: {:?}", test_name, graphql_files.keys().collect::<Vec<_>>());
+            }
+
             // Concatenate all files in deterministic order
             let mut combined_output = String::new();
             for (filename, content) in graphql_files {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.proto
@@ -74,3 +74,16 @@ message Bird {
   uint32 average_lifespan_years = 10;
   repeated string conservation_status = 11;
 }
+
+service BirdService {
+  rpc GetBirds(GetBirdsRequest) returns (GetBirdsResponse);
+}
+
+message GetBirdsRequest {
+  string name = 1;
+  string scientific_name = 2;
+}
+
+message GetBirdsResponse {
+  repeated Bird birds = 1;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.snap
@@ -6,7 +6,391 @@ input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.proto
 #--- schema.graphql ---#
 
 extend schema
-  @link(url: "https://grafbase.com/extensions/grpc/0.1.2", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "BirdService"
+        methods: [
+          {
+            name: "GetBirds"
+            inputType: ".GetBirdsRequest"
+            outputType: ".GetBirdsResponse"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".Bird"
+        fields: [
+          {
+            name: "name"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "scientific_name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "weight_in_kg"
+            number: 3
+            repeated: false
+            type: "double"
+          }
+          {
+            name: "is_migratory"
+            number: 4
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "size"
+            number: 5
+            repeated: false
+            type: ".Bird.Size"
+          }
+          {
+            name: "primary_habitat"
+            number: 6
+            repeated: false
+            type: ".Bird.Habitat"
+          }
+          {
+            name: "secondary_habitats"
+            number: 7
+            repeated: true
+            type: ".Bird.Habitat"
+          }
+          {
+            name: "diet"
+            number: 8
+            repeated: false
+            type: ".Bird.Diet"
+          }
+          {
+            name: "plumage"
+            number: 9
+            repeated: false
+            type: ".Bird.Plumage"
+          }
+          {
+            name: "average_lifespan_years"
+            number: 10
+            repeated: false
+            type: "uint32"
+          }
+          {
+            name: "conservation_status"
+            number: 11
+            repeated: true
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".Bird.Diet"
+        fields: [
+          {
+            name: "carnivorous"
+            number: 1
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "herbivorous"
+            number: 2
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "omnivorous"
+            number: 3
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "favorite_foods"
+            number: 4
+            repeated: true
+            type: "string"
+          }
+          {
+            name: "feeding_style"
+            number: 5
+            repeated: false
+            type: ".Bird.Diet.FeedingStyle"
+          }
+        ]
+      }
+      {
+        name: ".Bird.Plumage"
+        fields: [
+          {
+            name: "primary_color"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "secondary_colors"
+            number: 2
+            repeated: true
+            type: "string"
+          }
+          {
+            name: "has_distinct_mating_colors"
+            number: 3
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "pattern"
+            number: 4
+            repeated: false
+            type: ".Bird.Plumage.Pattern"
+          }
+        ]
+      }
+      {
+        name: ".GetBirdsRequest"
+        fields: [
+          {
+            name: "name"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "scientific_name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".GetBirdsResponse"
+        fields: [
+          {
+            name: "birds"
+            number: 1
+            repeated: true
+            type: ".Bird"
+          }
+        ]
+      }
+    ]
+  )
+  @protoEnums(
+    definitions: [
+      {
+        name: ".Bird.Diet.FeedingStyle"
+        values: [
+          {
+            name: "UNKNOWN_FEEDING_STYLE"
+            number: 0
+          }
+          {
+            name: "FORAGER"
+            number: 1
+          }
+          {
+            name: "HUNTER"
+            number: 2
+          }
+          {
+            name: "SCAVENGER"
+            number: 3
+          }
+          {
+            name: "FILTER_FEEDER"
+            number: 4
+          }
+        ]
+      }
+      {
+        name: ".Bird.Plumage.Pattern"
+        values: [
+          {
+            name: "UNKNOWN_PATTERN"
+            number: 0
+          }
+          {
+            name: "SOLID"
+            number: 1
+          }
+          {
+            name: "SPOTTED"
+            number: 2
+          }
+          {
+            name: "STRIPED"
+            number: 3
+          }
+          {
+            name: "MOTTLED"
+            number: 4
+          }
+          {
+            name: "BANDED"
+            number: 5
+          }
+        ]
+      }
+      {
+        name: ".Bird.Size"
+        values: [
+          {
+            name: "UNKNOWN_SIZE"
+            number: 0
+          }
+          {
+            name: "TINY"
+            number: 1
+          }
+          {
+            name: "SMALL"
+            number: 2
+          }
+          {
+            name: "MEDIUM"
+            number: 3
+          }
+          {
+            name: "LARGE"
+            number: 4
+          }
+          {
+            name: "EXTRA_LARGE"
+            number: 5
+          }
+        ]
+      }
+      {
+        name: ".Bird.Habitat"
+        values: [
+          {
+            name: "UNKNOWN_HABITAT"
+            number: 0
+          }
+          {
+            name: "FOREST"
+            number: 1
+          }
+          {
+            name: "WETLAND"
+            number: 2
+          }
+          {
+            name: "COASTAL"
+            number: 3
+          }
+          {
+            name: "DESERT"
+            number: 4
+          }
+          {
+            name: "GRASSLAND"
+            number: 5
+          }
+          {
+            name: "URBAN"
+            number: 6
+          }
+          {
+            name: "MOUNTAIN"
+            number: 7
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  BirdService_GetBirds(input: GetBirdsRequestInput): GetBirdsResponse @grpcMethod(service: "BirdService", method: "GetBirds")
+}
 
 "64 bit signed integer" scalar I64
 "64 bit unsigned integer" scalar U64
+
+input GetBirdsRequestInput {
+  name: String
+  scientific_name: String
+}
+
+type Bird {
+  name: String
+  scientific_name: String
+  weight_in_kg: Float
+  is_migratory: Boolean
+  size: Bird_Size
+  primary_habitat: Bird_Habitat
+  secondary_habitats: [Bird_Habitat!]
+  diet: Bird_Diet
+  plumage: Bird_Plumage
+  average_lifespan_years: Int
+  conservation_status: [String!]
+}
+
+type Bird_Diet {
+  carnivorous: Boolean
+  herbivorous: Boolean
+  omnivorous: Boolean
+  favorite_foods: [String!]
+  feeding_style: Bird_Diet_FeedingStyle
+}
+
+type Bird_Plumage {
+  primary_color: String
+  secondary_colors: [String!]
+  has_distinct_mating_colors: Boolean
+  pattern: Bird_Plumage_Pattern
+}
+
+type GetBirdsResponse {
+  birds: [Bird!]
+}
+
+enum Bird_Diet_FeedingStyle {
+  UNKNOWN_FEEDING_STYLE,
+  FORAGER,
+  HUNTER,
+  SCAVENGER,
+  FILTER_FEEDER,
+}
+
+enum Bird_Plumage_Pattern {
+  UNKNOWN_PATTERN,
+  SOLID,
+  SPOTTED,
+  STRIPED,
+  MOTTLED,
+  BANDED,
+}
+
+enum Bird_Size {
+  UNKNOWN_SIZE,
+  TINY,
+  SMALL,
+  MEDIUM,
+  LARGE,
+  EXTRA_LARGE,
+}
+
+enum Bird_Habitat {
+  UNKNOWN_HABITAT,
+  FOREST,
+  WETLAND,
+  COASTAL,
+  DESERT,
+  GRASSLAND,
+  URBAN,
+  MOUNTAIN,
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/echo.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/echo.snap
@@ -6,7 +6,7 @@ input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/echo.proto
 #--- schema.graphql ---#
 
 extend schema
-  @link(url: "https://grafbase.com/extensions/grpc/0.1.2", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
   @protoServices(
     definitions: [
       {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.proto
@@ -26,6 +26,7 @@ extend google.protobuf.EnumValueOptions {
 extend google.protobuf.ServiceOptions {
   optional bool default_to_query_fields = 58301;
   optional bool default_to_mutation_fields = 58302;
+  optional string subgraph_name = 58303;
 }
 
 extend google.protobuf.MethodOptions {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.snap
@@ -6,7 +6,7 @@ input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.proto
 #--- schema.graphql ---#
 
 extend schema
-  @link(url: "https://grafbase.com/extensions/grpc/0.1.2", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
   @protoServices(
     definitions: [
       {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.proto
@@ -1,0 +1,153 @@
+//!file:grafbase/options.proto
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+package grafbase.graphql;
+
+extend google.protobuf.MessageOptions {
+  optional string object_directives = 58301;
+  optional string input_object_directives = 58302;
+}
+
+extend google.protobuf.FieldOptions {
+  optional string output_field_directives = 58301;
+  optional string input_field_directives = 58302;
+}
+
+extend google.protobuf.EnumOptions {
+  optional string enum_directives = 58301;
+}
+
+extend google.protobuf.EnumValueOptions {
+  optional string enum_value_directives = 58301;
+}
+
+extend google.protobuf.ServiceOptions {
+  optional bool default_to_query_fields = 58301;
+  optional bool default_to_mutation_fields = 58302;
+  optional string subgraph_name = 58303;
+}
+
+extend google.protobuf.MethodOptions {
+  optional string directives = 58301;
+  optional bool is_query = 58302;
+  optional bool is_mutation = 58303;
+}
+
+//!file:multi_subgraph.proto
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package example;
+
+// Shared types
+message User {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+}
+
+message Product {
+  string id = 1;
+  string name = 2;
+  double price = 3;
+  string owner_id = 4;
+}
+
+message Order {
+  string id = 1;
+  string user_id = 2;
+  repeated string product_ids = 3;
+  double total = 4;
+}
+
+// User service - will go to users subgraph
+service UserService {
+  option (grafbase.graphql.subgraph_name) = "users";
+
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc CreateUser(CreateUserRequest) returns (User);
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message CreateUserRequest {
+  string name = 1;
+  string email = 2;
+}
+
+message ListUsersRequest {
+  int32 limit = 1;
+  string cursor = 2;
+}
+
+message ListUsersResponse {
+  repeated User users = 1;
+  string next_cursor = 2;
+}
+
+// Product service - will go to products subgraph
+service ProductService {
+  option (grafbase.graphql.subgraph_name) = "products";
+
+  rpc GetProduct(GetProductRequest) returns (Product);
+  rpc CreateProduct(CreateProductRequest) returns (Product);
+  rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
+}
+
+message GetProductRequest {
+  string id = 1;
+}
+
+message CreateProductRequest {
+  string name = 1;
+  double price = 2;
+  string owner_id = 3;
+}
+
+message ListProductsRequest {
+  int32 limit = 1;
+  string cursor = 2;
+}
+
+message ListProductsResponse {
+  repeated Product products = 1;
+  string next_cursor = 2;
+}
+
+// Order service - will go to orders subgraph  
+service OrderService {
+  option (grafbase.graphql.subgraph_name) = "orders";
+
+  rpc CreateOrder(CreateOrderRequest) returns (Order);
+  rpc GetOrder(GetOrderRequest) returns (Order);
+}
+
+message GetOrderRequest {
+  string id = 1;
+}
+
+message CreateOrderRequest {
+  string user_id = 1;
+  repeated string product_ids = 2;
+}
+
+// Analytics service - has no subgraph_name, so will be ignored in multi-file mode
+service AnalyticsService {
+  rpc GetStats(GetStatsRequest) returns (GetStatsResponse);
+}
+
+message GetStatsRequest {
+  string from_date = 1;
+  string to_date = 2;
+}
+
+message GetStatsResponse {
+  int32 total_orders = 1;
+  double total_revenue = 2;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.snap
@@ -1,0 +1,434 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.proto
+---
+#--- orders.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "example.OrderService"
+        methods: [
+          {
+            name: "CreateOrder"
+            inputType: ".example.CreateOrderRequest"
+            outputType: ".example.Order"
+          }
+          {
+            name: "GetOrder"
+            inputType: ".example.GetOrderRequest"
+            outputType: ".example.Order"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".example.Order"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "user_id"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "product_ids"
+            number: 3
+            repeated: true
+            type: "string"
+          }
+          {
+            name: "total"
+            number: 4
+            repeated: false
+            type: "double"
+          }
+        ]
+      }
+      {
+        name: ".example.GetOrderRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.CreateOrderRequest"
+        fields: [
+          {
+            name: "user_id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "product_ids"
+            number: 2
+            repeated: true
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  example_OrderService_CreateOrder(input: example_CreateOrderRequestInput): example_Order @grpcMethod(service: "example.OrderService", method: "CreateOrder")
+  example_OrderService_GetOrder(input: example_GetOrderRequestInput): example_Order @grpcMethod(service: "example.OrderService", method: "GetOrder")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input example_GetOrderRequestInput {
+  id: String
+}
+
+input example_CreateOrderRequestInput {
+  user_id: String
+  product_ids: [String!]
+}
+
+type example_Order {
+  id: String
+  user_id: String
+  product_ids: [String!]
+  total: Float
+}
+
+#--- products.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "example.ProductService"
+        methods: [
+          {
+            name: "GetProduct"
+            inputType: ".example.GetProductRequest"
+            outputType: ".example.Product"
+          }
+          {
+            name: "CreateProduct"
+            inputType: ".example.CreateProductRequest"
+            outputType: ".example.Product"
+          }
+          {
+            name: "ListProducts"
+            inputType: ".example.ListProductsRequest"
+            outputType: ".example.ListProductsResponse"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".example.Product"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "price"
+            number: 3
+            repeated: false
+            type: "double"
+          }
+          {
+            name: "owner_id"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.GetProductRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.CreateProductRequest"
+        fields: [
+          {
+            name: "name"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "price"
+            number: 2
+            repeated: false
+            type: "double"
+          }
+          {
+            name: "owner_id"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.ListProductsRequest"
+        fields: [
+          {
+            name: "limit"
+            number: 1
+            repeated: false
+            type: "int32"
+          }
+          {
+            name: "cursor"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.ListProductsResponse"
+        fields: [
+          {
+            name: "products"
+            number: 1
+            repeated: true
+            type: ".example.Product"
+          }
+          {
+            name: "next_cursor"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  example_ProductService_GetProduct(input: example_GetProductRequestInput): example_Product @grpcMethod(service: "example.ProductService", method: "GetProduct")
+  example_ProductService_CreateProduct(input: example_CreateProductRequestInput): example_Product @grpcMethod(service: "example.ProductService", method: "CreateProduct")
+  example_ProductService_ListProducts(input: example_ListProductsRequestInput): example_ListProductsResponse @grpcMethod(service: "example.ProductService", method: "ListProducts")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input example_GetProductRequestInput {
+  id: String
+}
+
+input example_CreateProductRequestInput {
+  name: String
+  price: Float
+  owner_id: String
+}
+
+input example_ListProductsRequestInput {
+  limit: Int
+  cursor: String
+}
+
+type example_Product {
+  id: String
+  name: String
+  price: Float
+  owner_id: String
+}
+
+type example_ListProductsResponse {
+  products: [example_Product!]
+  next_cursor: String
+}
+
+#--- users.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "example.UserService"
+        methods: [
+          {
+            name: "GetUser"
+            inputType: ".example.GetUserRequest"
+            outputType: ".example.User"
+          }
+          {
+            name: "CreateUser"
+            inputType: ".example.CreateUserRequest"
+            outputType: ".example.User"
+          }
+          {
+            name: "ListUsers"
+            inputType: ".example.ListUsersRequest"
+            outputType: ".example.ListUsersResponse"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".example.User"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "email"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.GetUserRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.CreateUserRequest"
+        fields: [
+          {
+            name: "name"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "email"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.ListUsersRequest"
+        fields: [
+          {
+            name: "limit"
+            number: 1
+            repeated: false
+            type: "int32"
+          }
+          {
+            name: "cursor"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.ListUsersResponse"
+        fields: [
+          {
+            name: "users"
+            number: 1
+            repeated: true
+            type: ".example.User"
+          }
+          {
+            name: "next_cursor"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  example_UserService_GetUser(input: example_GetUserRequestInput): example_User @grpcMethod(service: "example.UserService", method: "GetUser")
+  example_UserService_CreateUser(input: example_CreateUserRequestInput): example_User @grpcMethod(service: "example.UserService", method: "CreateUser")
+  example_UserService_ListUsers(input: example_ListUsersRequestInput): example_ListUsersResponse @grpcMethod(service: "example.UserService", method: "ListUsers")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input example_GetUserRequestInput {
+  id: String
+}
+
+input example_CreateUserRequestInput {
+  name: String
+  email: String
+}
+
+input example_ListUsersRequestInput {
+  limit: Int
+  cursor: String
+}
+
+"""
+Shared types
+"""
+type example_User {
+  id: String
+  name: String
+  email: String
+}
+
+type example_ListUsersResponse {
+  users: [example_User!]
+  next_cursor: String
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/no_services.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/no_services.proto
@@ -1,3 +1,4 @@
+//!file:grafbase/options.proto
 syntax = "proto2";
 
 import "google/protobuf/descriptor.proto";
@@ -32,4 +33,30 @@ extend google.protobuf.MethodOptions {
   optional string directives = 58301;
   optional bool is_query = 58302;
   optional bool is_mutation = 58303;
+}
+
+//!file:no_services.proto
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package example;
+
+// Just messages and enums, no services
+message User {
+  string id = 1;
+  string name = 2;
+  UserStatus status = 3;
+}
+
+message Product {
+  string id = 1;
+  string name = 2;
+  double price = 3;
+}
+
+enum UserStatus {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/no_services.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/no_services.snap
@@ -1,0 +1,6 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/no_services.proto
+---
+

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/routeguide.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/routeguide.snap
@@ -6,7 +6,7 @@ input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/routeguide.proto
 #--- schema.graphql ---#
 
 extend schema
-  @link(url: "https://grafbase.com/extensions/grpc/0.1.2", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
   @protoServices(
     definitions: [
       {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.proto
@@ -1,0 +1,93 @@
+//!file:grafbase/options.proto
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+package grafbase.graphql;
+
+extend google.protobuf.MessageOptions {
+  optional string object_directives = 58301;
+  optional string input_object_directives = 58302;
+}
+
+extend google.protobuf.FieldOptions {
+  optional string output_field_directives = 58301;
+  optional string input_field_directives = 58302;
+}
+
+extend google.protobuf.EnumOptions {
+  optional string enum_directives = 58301;
+}
+
+extend google.protobuf.EnumValueOptions {
+  optional string enum_value_directives = 58301;
+}
+
+extend google.protobuf.ServiceOptions {
+  optional bool default_to_query_fields = 58301;
+  optional bool default_to_mutation_fields = 58302;
+  optional string subgraph_name = 58303;
+}
+
+extend google.protobuf.MethodOptions {
+  optional string directives = 58301;
+  optional bool is_query = 58302;
+  optional bool is_mutation = 58303;
+}
+
+//!file:shared_subgraphs.proto
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package example;
+
+// Two services mapping to "accounts" subgraph
+service UserService {
+  option (grafbase.graphql.subgraph_name) = "accounts";
+  
+  rpc GetUser(GetUserRequest) returns (User);
+}
+
+service AuthService {
+  option (grafbase.graphql.subgraph_name) = "accounts";
+  
+  rpc Login(LoginRequest) returns (LoginResponse);
+}
+
+// One service mapping to "products" subgraph
+service ProductService {
+  option (grafbase.graphql.subgraph_name) = "products";
+  
+  rpc GetProduct(GetProductRequest) returns (Product);
+}
+
+// Request/Response messages
+message GetUserRequest {
+  string id = 1;
+}
+
+message User {
+  string id = 1;
+  string name = 2;
+}
+
+message LoginRequest {
+  string username = 1;
+  string password = 2;
+}
+
+message LoginResponse {
+  string token = 1;
+  User user = 2;
+}
+
+message GetProductRequest {
+  string id = 1;
+}
+
+message Product {
+  string id = 1;
+  string name = 2;
+  double price = 3;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.snap
@@ -1,0 +1,203 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.proto
+---
+#--- accounts.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "example.UserService"
+        methods: [
+          {
+            name: "GetUser"
+            inputType: ".example.GetUserRequest"
+            outputType: ".example.User"
+          }
+        ]
+      }
+      {
+        name: "example.AuthService"
+        methods: [
+          {
+            name: "Login"
+            inputType: ".example.LoginRequest"
+            outputType: ".example.LoginResponse"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".example.GetUserRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.User"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.LoginRequest"
+        fields: [
+          {
+            name: "username"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "password"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.LoginResponse"
+        fields: [
+          {
+            name: "token"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "user"
+            number: 2
+            repeated: false
+            type: ".example.User"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  example_UserService_GetUser(input: example_GetUserRequestInput): example_User @grpcMethod(service: "example.UserService", method: "GetUser")
+  example_AuthService_Login(input: example_LoginRequestInput): example_LoginResponse @grpcMethod(service: "example.AuthService", method: "Login")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+"""
+Request/Response messages
+"""
+input example_GetUserRequestInput {
+  id: String
+}
+
+input example_LoginRequestInput {
+  username: String
+  password: String
+}
+
+type example_User {
+  id: String
+  name: String
+}
+
+type example_LoginResponse {
+  token: String
+  user: example_User
+}
+
+#--- products.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "example.ProductService"
+        methods: [
+          {
+            name: "GetProduct"
+            inputType: ".example.GetProductRequest"
+            outputType: ".example.Product"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".example.GetProductRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".example.Product"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "price"
+            number: 3
+            repeated: false
+            type: "double"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  example_ProductService_GetProduct(input: example_GetProductRequestInput): example_Product @grpcMethod(service: "example.ProductService", method: "GetProduct")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input example_GetProductRequestInput {
+  id: String
+}
+
+type example_Product {
+  id: String
+  name: String
+  price: Float
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/taqueria.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/taqueria.snap
@@ -6,7 +6,7 @@ input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/taqueria.proto
 #--- schema.graphql ---#
 
 extend schema
-  @link(url: "https://grafbase.com/extensions/grpc/0.1.2", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
   @protoServices(
     definitions: [
       {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/well_known_types.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/well_known_types.snap
@@ -6,7 +6,7 @@ input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/well_known_types.pr
 #--- schema.graphql ---#
 
 extend schema
-  @link(url: "https://grafbase.com/extensions/grpc/0.1.2", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
   @protoServices(
     definitions: [
       {


### PR DESCRIPTION
Until now, protoc-gen-grafbase-subgraph would take all your protocol buffer definitions, and generate a single subgraph schema with all your services.

This does not match the real world, where different gRPC servers will implement different services from the same proto files.

This PR adds a `grafbase.graphql.subgraph_name` option to RPC services, indicating that they map to a specific subgraph.

Example:

```proto
import "grafbase/options.proto";

service UserService {
  option (grafbase.graphql.subgraph_name) = "users";

  rpc GetUser(GetUserRequest) returns (User);
  rpc CreateUser(CreateUserRequest) returns (User);
}

service ProductService {
  option (grafbase.graphql.subgraph_name) = "products";

  rpc GetProduct(GetProductRequest) returns (Product);
  rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
}

service OrderService {
  option (grafbase.graphql.subgraph_name) = "orders";

  rpc CreateOrder(CreateOrderRequest) returns (Order);
}
```

Summary:
- Added subgraph_name option (58303) to ServiceOptions in protobuf schema
- Services with subgraph_name generate separate <subgraph_name>.graphql files  
- That happens whenever any service has a subgraph_name, otherwise we use the previous logic of every service into one subgraph
- Each subgraph file contains only the services and types relevant to that subgraph
- Services without subgraph_name are ignored in multi-file mode