### PR TITLE
protoc-gen-grafbase-subgraph: add new schema_directives option on services

### DIFF
--- a/cli/protoc-gen-grafbase-subgraph/README.md
+++ b/cli/protoc-gen-grafbase-subgraph/README.md
@@ -97,6 +97,42 @@ enum Color {
 }
 ```
 
+### Adding schema directives
+
+You can add directives to the GraphQL schema extension using the `schema_directives` option at the service level:
+
+```protobuf
+import "grafbase/options.proto";
+
+service MyService {
+  option (grafbase.graphql.schema_directives) = "@contact(name: \"API Support\", url: \"https://api.example.com/support\")";
+  
+  rpc GetItem(GetItemRequest) returns (Item);
+}
+
+service AnotherService {
+  option (grafbase.graphql.schema_directives) = "@tag(name: \"backend\") @auth(rules: [{allow: \"admin\"}])";
+  
+  rpc UpdateItem(UpdateItemRequest) returns (Item);
+}
+```
+
+This will generate:
+
+```graphql
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @contact(name: "API Support", url: "https://api.example.com/support")
+  @tag(name: "backend") @auth(rules: [{allow: "admin"}])
+  ...
+```
+
+#### Schema directive behavior
+
+- **Deduplication**: If multiple services specify the same directive, it will only appear once in the schema extension
+- **Multi-file mode**: When using `subgraph_name`, only directives from services in that subgraph are included
+- **Multiple directives**: You can include multiple directives in a single string, separated by spaces
+
 ### Mapping specific services to different subgraphs
 
 By default, the plugin generates a single `schema.graphql` file containing all services. However, you can map different services to different subgraph files using the `subgraph_name` option:

--- a/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
+++ b/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
@@ -26,6 +26,7 @@ extend google.protobuf.ServiceOptions {
   optional bool default_to_query_fields = 58301;
   optional bool default_to_mutation_fields = 58302;
   optional string subgraph_name = 58303;
+  optional string schema_directives = 58304;
 }
 
 extend google.protobuf.MethodOptions {

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
@@ -62,6 +62,7 @@ pub(crate) struct ProtoService {
     pub(crate) default_to_query_fields: bool,
     pub(crate) default_to_mutation_fields: bool,
     pub(crate) subgraph_name: Option<String>,
+    pub(crate) schema_directives: Option<String>,
 }
 
 impl ProtoService {

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
@@ -123,6 +123,7 @@ fn translate_service(
         default_to_query_fields: false,
         default_to_mutation_fields: false,
         subgraph_name: None,
+        schema_directives: None,
     };
 
     extract_service_graphql_options_from_options(service, &mut proto_service);
@@ -491,9 +492,20 @@ fn extract_service_graphql_options_from_options(service: &ServiceDescriptorProto
             _ => None,
         });
 
+    let schema_directives = service
+        .options
+        .special_fields
+        .unknown_fields()
+        .get(SCHEMA_DIRECTIVES)
+        .and_then(|unknown_value_ref| match unknown_value_ref {
+            protobuf::UnknownValueRef::LengthDelimited(items) => Some(str::from_utf8(items).unwrap().to_owned()),
+            _ => None,
+        });
+
     proto_service.default_to_query_fields = graphql_default_to_query_fields;
     proto_service.default_to_mutation_fields = graphql_default_to_mutation_fields;
     proto_service.subgraph_name = subgraph_name;
+    proto_service.schema_directives = schema_directives;
 }
 
 fn extract_method_graphql_options_from_options(

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
@@ -10,6 +10,7 @@ pub(super) const ENUM_VALUE_DIRECTIVES: u32 = 58301;
 pub(super) const DEFAULT_TO_QUERY_FIELDS: u32 = 58301;
 pub(super) const DEFAULT_TO_MUTATION_FIELDS: u32 = 58302;
 pub(super) const SUBGRAPH_NAME: u32 = 58303;
+pub(super) const SCHEMA_DIRECTIVES: u32 = 58304;
 
 pub(super) const DIRECTIVES: u32 = 58301;
 pub(super) const IS_QUERY: u32 = 58302;

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.proto
@@ -1,0 +1,124 @@
+//!file:grafbase/options.proto
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+package grafbase.graphql;
+
+extend google.protobuf.MessageOptions {
+  optional string object_directives = 58301;
+  optional string input_object_directives = 58302;
+}
+
+extend google.protobuf.FieldOptions {
+  optional string output_field_directives = 58301;
+  optional string input_field_directives = 58302;
+}
+
+extend google.protobuf.EnumOptions {
+  optional string enum_directives = 58301;
+}
+
+extend google.protobuf.EnumValueOptions {
+  optional string enum_value_directives = 58301;
+}
+
+extend google.protobuf.ServiceOptions {
+  optional bool default_to_query_fields = 58301;
+  optional bool default_to_mutation_fields = 58302;
+  optional string subgraph_name = 58303;
+  optional string schema_directives = 58304;
+}
+
+extend google.protobuf.MethodOptions {
+  optional string directives = 58301;
+  optional bool is_query = 58302;
+  optional bool is_mutation = 58303;
+}
+
+//!file:schema_directives.proto
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package test.schema;
+
+// Test services with different schema directives
+service FirstService {
+  option (grafbase.graphql.schema_directives) = "@contact(name: \"API Support\", url: \"https://api.example.com/support\")";
+  
+  rpc GetItem(GetItemRequest) returns (Item);
+}
+
+service SecondService {
+  option (grafbase.graphql.schema_directives) = "@tag(name: \"backend\")";
+  
+  rpc UpdateItem(UpdateItemRequest) returns (Item);
+}
+
+service ThirdService {
+  option (grafbase.graphql.schema_directives) = "@contact(name: \"API Support\", url: \"https://api.example.com/support\")";
+  option (grafbase.graphql.subgraph_name) = "items";
+  
+  rpc DeleteItem(DeleteItemRequest) returns (DeleteItemResponse);
+}
+
+// This service has no schema directives
+service FourthService {
+  rpc ListItems(ListItemsRequest) returns (ListItemsResponse);
+}
+
+// Multi-directive service
+service FifthService {
+  option (grafbase.graphql.schema_directives) = "@tag(name: \"experimental\") @auth(rules: [{allow: \"admin\"}])";
+  
+  rpc CreateItem(CreateItemRequest) returns (Item);
+}
+
+// Service in same subgraph with different directives (to test deduplication)
+service SixthService {
+  option (grafbase.graphql.schema_directives) = "@tag(name: \"backend\")";
+  option (grafbase.graphql.subgraph_name) = "items";
+  
+  rpc GetItemDetails(GetItemRequest) returns (Item);
+}
+
+// Messages
+message Item {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+}
+
+message GetItemRequest {
+  string id = 1;
+}
+
+message UpdateItemRequest {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+}
+
+message CreateItemRequest {
+  string name = 1;
+  string description = 2;
+}
+
+message DeleteItemRequest {
+  string id = 1;
+}
+
+message DeleteItemResponse {
+  bool success = 1;
+}
+
+message ListItemsRequest {
+  int32 limit = 1;
+  string cursor = 2;
+}
+
+message ListItemsResponse {
+  repeated Item items = 1;
+  string next_cursor = 2;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.snap
@@ -1,0 +1,124 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.proto
+---
+#--- items.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @contact(name: "API Support", url: "https://api.example.com/support")
+  @tag(name: "backend")
+  @protoServices(
+    definitions: [
+      {
+        name: "test.schema.ThirdService"
+        methods: [
+          {
+            name: "DeleteItem"
+            inputType: ".test.schema.DeleteItemRequest"
+            outputType: ".test.schema.DeleteItemResponse"
+          }
+        ]
+      }
+      {
+        name: "test.schema.SixthService"
+        methods: [
+          {
+            name: "GetItemDetails"
+            inputType: ".test.schema.GetItemRequest"
+            outputType: ".test.schema.Item"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.schema.Item"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "description"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.schema.GetItemRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.schema.DeleteItemRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.schema.DeleteItemResponse"
+        fields: [
+          {
+            name: "success"
+            number: 1
+            repeated: false
+            type: "bool"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  test_schema_ThirdService_DeleteItem(input: test_schema_DeleteItemRequestInput): test_schema_DeleteItemResponse @grpcMethod(service: "test.schema.ThirdService", method: "DeleteItem")
+  test_schema_SixthService_GetItemDetails(input: test_schema_GetItemRequestInput): test_schema_Item @grpcMethod(service: "test.schema.SixthService", method: "GetItemDetails")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input test_schema_GetItemRequestInput {
+  id: String
+}
+
+input test_schema_DeleteItemRequestInput {
+  id: String
+}
+
+"""
+Messages
+"""
+type test_schema_Item {
+  id: String
+  name: String
+  description: String
+}
+
+type test_schema_DeleteItemResponse {
+  success: Boolean
+}


### PR DESCRIPTION
Specifically for composite schema imports.

See the example in the README.