### PR TITLE
protoc-gen-grafbase-subgraph: proper @derive support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +108,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +142,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -136,15 +211,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
  "yansi",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii_utils"
@@ -164,6 +254,17 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
@@ -172,6 +273,51 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.3.0",
+ "futures-lite 2.6.0",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite 2.6.0",
+ "once_cell",
 ]
 
 [[package]]
@@ -266,6 +412,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "parking",
+ "polling",
+ "rustix 1.0.7",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,7 +466,7 @@ dependencies = [
  "serde_nanos",
  "serde_repr",
  "thiserror 1.0.69",
- "time",
+ "time 0.3.41",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -309,6 +484,32 @@ checksum = "8da2537846e16b96d2972ee52a3b355663872a1a687ce6d57a3b6f6b6a181c89"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -332,6 +533,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -473,6 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core 0.5.2",
+ "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -493,7 +701,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite",
@@ -544,6 +752,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,10 +778,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -640,11 +880,33 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "piper",
 ]
 
 [[package]]
@@ -671,12 +933,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -685,6 +969,9 @@ name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecheck"
@@ -722,6 +1009,12 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -798,6 +1091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +1147,7 @@ dependencies = [
  "anstyle",
  "clap_lex 0.7.5",
  "strsim 0.11.1",
+ "terminal_size",
 ]
 
 [[package]]
@@ -909,6 +1212,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +1251,29 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_fn"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+
+[[package]]
+name = "cookie"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+dependencies = [
+ "aes-gcm",
+ "base64 0.13.1",
+ "hkdf 0.10.0",
+ "hmac 0.10.1",
+ "percent-encoding",
+ "rand 0.8.5",
+ "sha2 0.9.9",
+ "time 0.2.27",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -980,6 +1320,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.122.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,7 +1356,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -1013,10 +1369,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.40",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -1062,6 +1475,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+
+[[package]]
 name = "ctor"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
+name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,9 +1524,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -1112,8 +1550,11 @@ checksum = "8931dbf88c6bc3a09e4721b8342a34d73abb0586ef9e4cb10712c994617b3347"
 dependencies = [
  "cynic-proc-macros",
  "ref-cast",
+ "reqwest 0.12.20",
  "serde",
+ "serde_json",
  "static_assertions",
+ "surf",
  "thiserror 1.0.69",
 ]
 
@@ -1156,6 +1597,7 @@ dependencies = [
  "indexmap 2.9.0",
  "lalrpop-util",
  "logos",
+ "pretty",
 ]
 
 [[package]]
@@ -1279,15 +1721,30 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
@@ -1376,7 +1833,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "thiserror 2.0.12",
- "time",
+ "time 0.3.41",
  "winnow",
 ]
 
@@ -1393,7 +1850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1416,6 +1873,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
 dependencies = [
+ "ct-codecs",
  "getrandom 0.2.16",
 ]
 
@@ -1428,7 +1886,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "subtle",
  "zeroize",
@@ -1450,16 +1908,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
+ "base64ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serde_json",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1489,6 +1950,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "engine-field-selection-map"
+version = "0.1.0"
+source = "git+https://github.com/grafbase/grafbase#07e36b93fa6e4a83dc37f1e3a6ef3ae5012d75a8"
+dependencies = [
+ "grafbase-workspace-hack 0.1.0 (git+https://github.com/grafbase/grafbase)",
+ "itertools 0.14.0",
+ "winnow",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1566,6 +2049,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -1581,9 +2070,15 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fast_chemail"
@@ -1592,6 +2087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
 dependencies = [
  "ascii_utils",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1621,6 +2125,9 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "flate2"
@@ -1762,11 +2269,26 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
- "fastrand",
+ "fastrand 2.3.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1842,6 +2364,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
@@ -1868,10 +2401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.9.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -1890,6 +2438,18 @@ dependencies = [
  "log",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1917,7 +2477,7 @@ dependencies = [
  "indexmap 2.9.0",
  "indoc",
  "itertools 0.14.0",
- "semver",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "sqlx",
@@ -1970,19 +2530,19 @@ dependencies = [
  "jaq-json",
  "jaq-std",
  "log",
- "minicbor-serde",
+ "minicbor-serde 0.6.0",
  "postcard",
  "regex",
  "reqwest 0.12.20",
  "rust_decimal",
- "semver",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "tempfile",
  "thiserror 2.0.12",
- "time",
+ "time 0.3.41",
  "tokio",
  "toml 0.9.4",
  "url",
@@ -2014,7 +2574,7 @@ dependencies = [
  "async-graphql-axum",
  "axum 0.8.4",
  "cynic-parser",
- "grafbase-workspace-hack",
+ "grafbase-workspace-hack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "tokio",
@@ -2026,6 +2586,164 @@ name = "grafbase-workspace-hack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebfd7fd1a0e3427f3e6c9ef7bc4e0d2f05c9e94ecf859176cdf297212fe8f06e"
+
+[[package]]
+name = "grafbase-workspace-hack"
+version = "0.1.0"
+source = "git+https://github.com/grafbase/grafbase#07e36b93fa6e4a83dc37f1e3a6ef3ae5012d75a8"
+dependencies = [
+ "addr2line",
+ "aho-corasick",
+ "anyhow",
+ "arrayvec 0.7.6",
+ "ascii",
+ "axum 0.8.4",
+ "axum-core 0.5.2",
+ "base16ct",
+ "bitflags 2.9.1",
+ "bumpalo",
+ "byteorder",
+ "bytes",
+ "cc",
+ "chrono",
+ "ciborium",
+ "clap 4.5.40",
+ "clap_builder",
+ "combine",
+ "concurrent-queue",
+ "cranelift-bitset",
+ "criterion",
+ "crossbeam-utils",
+ "curve25519-dalek",
+ "cynic",
+ "cynic-parser",
+ "der",
+ "deranged",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519",
+ "ed25519-compact",
+ "ed25519-dalek",
+ "either",
+ "elliptic-curve",
+ "event-listener 5.4.0",
+ "fastrand 2.3.0",
+ "ff",
+ "fixedbitset",
+ "form_urlencoded",
+ "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.16",
+ "getrandom 0.3.3",
+ "gimli",
+ "group",
+ "hashbrown 0.15.4",
+ "hex",
+ "http-types",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "iana-time-zone",
+ "idna",
+ "indexmap 2.9.0",
+ "insta",
+ "lazy_static",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "linux-raw-sys 0.9.4",
+ "log",
+ "lz4_flex",
+ "memchr",
+ "miette",
+ "mime_guess",
+ "minicbor 1.1.0",
+ "minicbor-serde 0.5.0",
+ "miniz_oxide",
+ "mio",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "object",
+ "once_cell",
+ "p256",
+ "p384",
+ "percent-encoding",
+ "pkcs1",
+ "pkcs8",
+ "portable-atomic",
+ "proc-macro2",
+ "prost",
+ "pulley-interpreter",
+ "quote",
+ "rand 0.8.5",
+ "rand 0.9.1",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "regex",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+ "reqwest 0.12.20",
+ "rsa",
+ "rustix 0.38.44",
+ "rustix 1.0.7",
+ "rustls",
+ "rustls-webpki 0.103.3",
+ "sec1",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "signal-hook",
+ "signature",
+ "similar",
+ "similar-asserts",
+ "smallvec",
+ "spin",
+ "spki",
+ "stable_deref_trait",
+ "standback",
+ "strum 0.27.1",
+ "subtle",
+ "syn 2.0.104",
+ "sync_wrapper 1.0.2",
+ "time 0.3.41",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+ "tonic 0.13.1",
+ "tower 0.5.2",
+ "tower-http",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "tungstenite 0.26.2",
+ "ulid",
+ "url",
+ "uuid",
+ "wasmparser",
+ "winapi",
+ "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+ "winnow",
+ "zeroize",
+ "zstd",
+ "zstd-safe",
+ "zstd-sys",
+]
 
 [[package]]
 name = "graphql-composition"
@@ -2051,7 +2769,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58cc60d2f3a2a838dfcb9f5cb9d2dfc56cf00d6a1100273eb353fef75e16005"
 dependencies = [
- "grafbase-workspace-hack",
+ "grafbase-workspace-hack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -2061,8 +2779,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa2e818b9e62654f2039d524c92a19495fcc2b0139ffc0354956865b3c7e939"
 dependencies = [
- "async-channel",
- "futures-lite",
+ "async-channel 2.3.1",
+ "futures-lite 2.6.0",
  "futures-sink",
  "futures-timer",
  "log",
@@ -2102,7 +2820,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tonic-build",
 ]
 
@@ -2195,6 +2913,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -2214,7 +2933,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "spin",
  "stable_deref_trait",
@@ -2254,6 +2973,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hifijson"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,11 +3025,31 @@ checksum = "9958ab3ce3170c061a27679916bd9b969eceeb5e8b120438e6751d0987655c42"
 
 [[package]]
 name = "hkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.10.1",
+]
+
+[[package]]
+name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2274,7 +3058,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2340,6 +3124,46 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-client"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "http-types",
+ "log",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel 1.9.0",
+ "async-std",
+ "base64 0.13.1",
+ "cookie",
+ "futures-lite 1.13.0",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -2409,6 +3233,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2649,6 +3474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,9 +3488,20 @@ dependencies = [
  "console",
  "globset",
  "once_cell",
+ "pest",
+ "pest_derive",
  "serde",
  "similar",
  "walkdir",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2667,6 +3509,18 @@ name = "integer-encoding"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
+]
 
 [[package]]
 name = "ipnet"
@@ -2683,6 +3537,23 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2859,13 +3730,13 @@ dependencies = [
  "chrono",
  "ciborium",
  "ed25519-compact",
- "hmac",
+ "hmac 0.12.1",
  "p256",
  "rand_core 0.6.4",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "subtle",
  "zeroize",
@@ -2891,6 +3762,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2954,6 +3834,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3032,6 +3918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,6 +3950,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
 name = "matchers"
@@ -3084,7 +3985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3092,6 +3993,36 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "mime"
@@ -3111,11 +4042,31 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
+dependencies = [
+ "minicbor-derive 0.17.0",
+]
+
+[[package]]
+name = "minicbor"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d2aa21725f9442def0570f427df351961a79439f63fff51b7d022a5ca31304"
 dependencies = [
- "minicbor-derive",
+ "minicbor-derive 0.18.0",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3131,11 +4082,21 @@ dependencies = [
 
 [[package]]
 name = "minicbor-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05d783cc8c3cdbde9f7ee9eeeef417810278e81fb6289634fdbc952d462fc23"
+dependencies = [
+ "minicbor 1.1.0",
+ "serde",
+]
+
+[[package]]
+name = "minicbor-serde"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bbf243b8cc68a7a76473b14328d3546fb002ae3d069227794520e9181003de9"
 dependencies = [
- "minicbor",
+ "minicbor 2.0.0",
  "serde",
 ]
 
@@ -3161,6 +4122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -3374,7 +4336,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3385,6 +4347,9 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.4",
+ "indexmap 2.9.0",
  "memchr",
 ]
 
@@ -3401,6 +4366,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openidconnect"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,7 +4387,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
- "hmac",
+ "hmac 0.12.1",
  "http 1.3.1",
  "itertools 0.10.5",
  "log",
@@ -3425,7 +4402,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -3545,6 +4522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3553,7 +4536,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3565,7 +4548,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3609,7 +4592,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3678,7 +4661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3724,6 +4707,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.3.0",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,6 +4743,59 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3827,6 +4874,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac98773b7109bc75f475ab5a134c9b64b87e59d776d31098d8f346922396a477"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,6 +4945,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3974,6 +5038,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.9.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which 4.4.2",
+]
+
+[[package]]
 name = "protobuf-support"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,10 +5081,13 @@ dependencies = [
 name = "protoc-gen-grafbase-subgraph"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
+ "engine-field-selection-map",
  "indexmap 2.9.0",
  "insta",
  "paste",
  "protobuf",
+ "protobuf-codegen",
  "protobuf-support",
  "tempfile",
  "walkdir",
@@ -4023,11 +5121,34 @@ dependencies = [
  "duct 0.13.7",
  "indoc",
  "reqwest 0.12.20",
- "semver",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "tokio",
  "toml 0.8.23",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4111,7 +5232,7 @@ name = "ramhorns"
 version = "1.0.1"
 source = "git+https://github.com/grafbase/ramhorns?branch=grafbase#cf17d841d507a1da7b357e7f8508a9f68be48a7a"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "beef",
  "fnv",
  "logos",
@@ -4128,6 +5249,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -4153,6 +5287,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -4169,6 +5313,15 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -4190,10 +5343,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "rapidhash"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9813f789f95ee4fe6b4d01834404d7cccacbc3f6c029343af910b3c2835eb9f1"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4341,11 +5523,15 @@ version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2 0.4.10",
+ "hickory-resolver",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4356,11 +5542,14 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4369,15 +5558,23 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.1",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "rest"
@@ -4402,7 +5599,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4456,7 +5653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4477,13 +5674,13 @@ checksum = "c8b534a23662bb559c5c73213be63ecd6524e774d291f3618c2b04b723d184eb"
 dependencies = [
  "base64 0.22.1",
  "core2",
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
  "pbkdf2",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
  "thiserror 1.0.69",
 ]
@@ -4520,7 +5717,7 @@ version = "1.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "borsh",
  "bytes",
  "num-traits",
@@ -4550,11 +5747,20 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -4729,6 +5935,7 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -4771,12 +5978,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -4859,6 +6081,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4915,7 +6148,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.41",
 ]
 
 [[package]]
@@ -4931,6 +6164,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4938,7 +6190,26 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4949,7 +6220,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5032,7 +6303,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5047,6 +6318,21 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+dependencies = [
+ "console",
+ "serde",
+ "similar",
+]
 
 [[package]]
 name = "slab"
@@ -5084,7 +6370,7 @@ dependencies = [
  "pkcs8",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "template",
  "tokio",
  "toml 0.9.4",
@@ -5151,7 +6437,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.4.0",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -5167,7 +6453,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.12",
  "tokio",
@@ -5205,7 +6491,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5227,7 +6513,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5236,8 +6522,8 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -5247,8 +6533,8 @@ dependencies = [
  "rand 0.8.5",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5274,8 +6560,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -5285,7 +6571,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5325,6 +6611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +6630,55 @@ name = "static_assertions_next"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1 0.6.1",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"
@@ -5408,6 +6752,47 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "surf"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "cfg-if",
+ "futures-util",
+ "getrandom 0.2.16",
+ "http-client",
+ "http-types",
+ "log",
+ "mime_guess",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "sval"
@@ -5600,7 +6985,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "fastrand",
+ "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
@@ -5629,6 +7014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "test-matrix"
 version = "0.1.0"
 dependencies = [
@@ -5643,6 +7038,10 @@ name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.1",
+]
 
 [[package]]
 name = "thiserror"
@@ -5695,6 +7094,21 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros 0.1.1",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
@@ -5705,7 +7119,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
+ "time-macros 0.2.22",
 ]
 
 [[package]]
@@ -5713,6 +7127,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
 
 [[package]]
 name = "time-macros"
@@ -5725,6 +7149,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5732,6 +7169,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5807,6 +7254,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5967,6 +7415,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-native-certs 0.8.1",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,9 +7484,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.9.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6022,16 +7501,27 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
+ "async-compression",
  "bitflags 2.9.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6091,6 +7581,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+ "valuable",
+ "valuable-serde",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6100,12 +7602,17 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
+ "valuable",
+ "valuable-serde",
 ]
 
 [[package]]
@@ -6137,7 +7644,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -6154,8 +7661,9 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.1",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.12",
+ "url",
  "utf-8",
 ]
 
@@ -6184,6 +7692,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.1",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6202,6 +7721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6217,16 +7742,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -6276,7 +7823,9 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -6285,6 +7834,16 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "valuable-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee0548edecd1b907be7e67789923b7d02275b9ba4a33ebc33300e2c947a8cb1"
+dependencies = [
+ "serde",
+ "valuable",
+]
 
 [[package]]
 name = "value-bag"
@@ -6335,6 +7894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6352,6 +7917,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -6468,6 +8039,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6476,7 +8060,17 @@ dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
  "indexmap 2.9.0",
- "semver",
+ "semver 1.0.26",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -6549,6 +8143,12 @@ dependencies = [
  "redox_syscall",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"
@@ -7022,7 +8622,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.9.0",
  "log",
- "semver",
+ "semver 1.0.26",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ clap = "4.5.36"
 ctor = "0.4"
 duration-str = "0.17"
 enumflags2 = "0.7.11"
+field-selection-map = { git = "https://github.com/grafbase/grafbase", package = "engine-field-selection-map" }
 futures = "0.3"
 futures-util = "0.3.31"
 fxhash = "0.2.1"

--- a/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
+++ b/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ### Added
 
+- **Input argument directives** added. You can now add GraphQL directives to RPC method input arguments using the `input_argument_directives` option on methods.
+
+- **Composite schema entity references with @derive** added. You can now create federation-style entity references using the `derive` option on messages:
+  - Use `option (grafbase.graphql.derive) = {entity: "User", is: "{ id: user_id }"};` on fields
+  - Automatically generates reference fields with `@derive` and `@is` directives
+  - Creates stub entity types with `@key` directives if the type is not already defined
+  - Supports custom relation field names with the `field` parameter
+  - The `is` parameter defines the field mapping using format `"{ <entity_key_field>: <proto_field> }"`
+  - The `@is` directive uses the value from the `is` parameter directly
+  - Enables cross-subgraph entity references in federated schemas
+
 - **Multiple subgraphs support** added. Support for generating multiple GraphQL files based on service annotations:
 
   - Services can now have a `subgraph_name` option that maps them to different subgraph files

--- a/cli/protoc-gen-grafbase-subgraph/Cargo.toml
+++ b/cli/protoc-gen-grafbase-subgraph/Cargo.toml
@@ -8,10 +8,15 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
+anyhow.workspace = true
+field-selection-map.workspace = true
 indexmap.workspace = true
 paste.workspace = true
 protobuf.workspace = true
 protobuf-support.workspace = true
+
+[build-dependencies]
+protobuf-codegen = "3"
 
 [dev-dependencies]
 insta.workspace = true

--- a/cli/protoc-gen-grafbase-subgraph/build.rs
+++ b/cli/protoc-gen-grafbase-subgraph/build.rs
@@ -1,0 +1,12 @@
+use std::io::Result;
+
+fn main() -> Result<()> {
+    protobuf_codegen::Codegen::new()
+        .pure()
+        .cargo_out_dir("protos")
+        .include("proto")
+        .input("proto/grafbase/options.proto")
+        .run_from_script();
+
+    Ok(())
+}

--- a/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
+++ b/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
@@ -4,9 +4,16 @@ import "google/protobuf/descriptor.proto";
 
 package grafbase.graphql;
 
+message CompositeSchemaEntity {
+  optional string entity = 1;
+  optional string field = 2;
+  optional string is = 3;
+}
+
 extend google.protobuf.MessageOptions {
   optional string object_directives = 58301;
   optional string input_object_directives = 58302;
+  repeated CompositeSchemaEntity derive = 58303;
 }
 
 extend google.protobuf.FieldOptions {

--- a/cli/protoc-gen-grafbase-subgraph/src/main.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/main.rs
@@ -1,4 +1,5 @@
 mod display_utils;
+mod options_proto;
 mod render_graphql_sdl;
 mod schema;
 mod translate_schema;
@@ -70,7 +71,8 @@ fn generate(raw_request: &[u8]) -> CodeGeneratorResponse {
         // Generate a file for each subgraph
         for (subgraph_name, service_ids) in services_by_subgraph {
             let mut graphql_schema = String::new();
-            render_graphql_sdl_filtered(&translated_schema, Some(&service_ids), &mut graphql_schema).unwrap();
+            render_graphql_sdl_filtered(&translated_schema, Some(&service_ids), &mut graphql_schema)
+                .expect("Failed to render GraphQL schema");
 
             let mut file = File::new();
             file.set_name(format!("{}.graphql", subgraph_name));
@@ -80,7 +82,7 @@ fn generate(raw_request: &[u8]) -> CodeGeneratorResponse {
     } else {
         // Single-file mode: generate schema.graphql
         let mut graphql_schema = String::new();
-        render_graphql_sdl(&translated_schema, &mut graphql_schema).unwrap();
+        render_graphql_sdl(&translated_schema, &mut graphql_schema).expect("Failed to render GraphQL schema");
 
         let mut file = File::new();
         file.set_name("schema.graphql".to_owned());

--- a/cli/protoc-gen-grafbase-subgraph/src/options_proto.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/options_proto.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));

--- a/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/schema_directives.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/schema_directives.rs
@@ -6,7 +6,6 @@ pub(super) fn render_schema_directives_filtered(
     types_to_render: &services::TypesToRender,
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
-    // Collect all unique schema directives from the services
     let mut all_schema_directives = Vec::new();
 
     let services = if let Some(ids) = service_ids {
@@ -24,13 +23,11 @@ pub(super) fn render_schema_directives_filtered(
         }
     }
 
-    // Remove duplicates while preserving order
     let mut seen = std::collections::HashSet::new();
     let unique_directives: Vec<_> = all_schema_directives.into_iter().filter(|d| seen.insert(*d)).collect();
 
     f.write_str("extend schema\n  @link(url: \"https://grafbase.com/extensions/grpc/0.2.0\", import: [\"@protoServices\", \"@protoEnums\", \"@protoMessages\", \"@grpcMethod\"])\n")?;
 
-    // Add additional schema directives
     for directive in unique_directives {
         f.write_str("  ")?;
         f.write_str(directive)?;

--- a/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
@@ -121,7 +121,7 @@ fn render_method_field(
 
     f.write_str("): ")?;
 
-    render_output_field_type(schema, &method.output_type, false, f)?;
+    render_output_field_type(schema, &method.output_type, false, true, f)?;
 
     write!(
         f,

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
@@ -3,7 +3,10 @@ use std::{
     str::FromStr,
 };
 
-use crate::display_utils::{self, display_fn, grpc_path_to_graphql_name};
+use crate::{
+    display_utils::{self, display_fn, grpc_path_to_graphql_name},
+    translate_schema::derive::SimpleIs,
+};
 
 use super::{Parent, ids::*};
 
@@ -21,6 +24,7 @@ pub(crate) struct ProtoMessage {
     pub(crate) description: Option<String>,
     pub(crate) input_object_directives: Option<String>,
     pub(crate) object_directives: Option<String>,
+    pub(crate) derives: Vec<CompositeSchemaEntity>,
 }
 
 impl ProtoMessage {
@@ -34,6 +38,13 @@ impl ProtoMessage {
             f.write_str("Input")
         })
     }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct CompositeSchemaEntity {
+    pub(crate) entity: String,
+    pub(crate) field: Option<String>,
+    pub(crate) is: Option<SimpleIs>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema/derive.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema/derive.rs
@@ -1,0 +1,267 @@
+use std::fmt;
+
+use field_selection_map::{Path, PathSegment, SelectedObjectField, SelectedValue};
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct SimpleIs {
+    pub(crate) fields: Vec<SimpleIsField>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct SimpleIsField {
+    pub(crate) input_field_name: String,
+    pub(crate) output_field_name: String,
+}
+
+impl fmt::Display for SimpleIs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("{")?;
+
+        for (i, field) in self.fields.iter().enumerate() {
+            if i > 0 {
+                f.write_str(",")?;
+            }
+            f.write_str(" ")?;
+            f.write_str(&field.output_field_name)?;
+            f.write_str(": ")?;
+            f.write_str(&field.input_field_name)?;
+        }
+
+        if !self.fields.is_empty() {
+            f.write_str(" ")?;
+        }
+        f.write_str("}")
+    }
+}
+
+const UNACCEPTABLE_IS_ERROR: &str = r#"
+Failed to parse `is:` argument to `derive`. The argument must be a string of the following shape: "{ target_field_name: source_field_name }".
+"#;
+
+pub(crate) fn extract_is(is: &str) -> anyhow::Result<SimpleIs> {
+    let map = field_selection_map::SelectedValue::try_from(is)
+        .map_err(|err| anyhow::anyhow!("Failed to parse as a field selection map: {err}"))?;
+    let [field_selection_map::SelectedValueEntry::Object { path: None, object }] = map.alternatives.as_slice() else {
+        anyhow::bail!(UNACCEPTABLE_IS_ERROR);
+    };
+
+    let mut fields = Vec::with_capacity(4);
+
+    for field in &object.fields {
+        let field = extract_field(field)?;
+
+        fields.push(field);
+    }
+
+    Ok(SimpleIs { fields })
+}
+
+fn extract_field(
+    field_selection_map::SelectedObjectField { key, value }: &SelectedObjectField,
+) -> anyhow::Result<SimpleIsField> {
+    let Some(SelectedValue { alternatives }) = value else {
+        anyhow::bail!(UNACCEPTABLE_IS_ERROR);
+    };
+
+    let [field_selection_map::SelectedValueEntry::Path(Path { ty: None, segments })] = alternatives.as_slice() else {
+        anyhow::bail!(UNACCEPTABLE_IS_ERROR);
+    };
+
+    let [PathSegment { ty: None, field }] = segments.as_slice() else {
+        anyhow::bail!(UNACCEPTABLE_IS_ERROR);
+    };
+
+    Ok(SimpleIsField {
+        input_field_name: (*field).to_owned(),
+        output_field_name: (*key).to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_is_basic_success() {
+        let is = r#"{ target: source }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Ok(
+            SimpleIs {
+                fields: [
+                    SimpleIsField {
+                        input_field_name: "source",
+                        output_field_name: "target",
+                    },
+                ],
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_with_underscores() {
+        let is = r#"{ output_field: input_field }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Ok(
+            SimpleIs {
+                fields: [
+                    SimpleIsField {
+                        input_field_name: "input_field",
+                        output_field_name: "output_field",
+                    },
+                ],
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_with_camel_case() {
+        let is = r#"{ targetFieldName: sourceFieldName }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Ok(
+            SimpleIs {
+                fields: [
+                    SimpleIsField {
+                        input_field_name: "sourceFieldName",
+                        output_field_name: "targetFieldName",
+                    },
+                ],
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_composite() {
+        let is = r#"{ target1: source1 target2: source2 }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Ok(
+            SimpleIs {
+                fields: [
+                    SimpleIsField {
+                        input_field_name: "source1",
+                        output_field_name: "target1",
+                    },
+                    SimpleIsField {
+                        input_field_name: "source2",
+                        output_field_name: "target2",
+                    },
+                ],
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_invalid_field_selection_map() {
+        let is = r#"{ target: source"#; // Missing closing brace
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "Failed to parse as a field selection map: { target: source\n                ^\ninvalid object",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_non_object() {
+        let is = r#""not an object""#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "Failed to parse as a field selection map: \"not an object\"\n^\ninvalid name",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_array() {
+        let is = r#"[{ target: source }]"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "\nFailed to parse `is:` argument to `derive`. The argument must be a string of the following shape: \"{ target_field_name: source_field_name }\".\n",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_empty_object() {
+        let is = r#"{}"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Ok(
+            SimpleIs {
+                fields: [],
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_multiple_fields_with_commas() {
+        let is = r#"{ target1: source1, target2: source2 }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "Failed to parse as a field selection map: { target1: source1, target2: source2 }\n                  ^\ninvalid object",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_non_string_value() {
+        let is = r#"{ target: 123 }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "Failed to parse as a field selection map: { target: 123 }\n        ^\ninvalid object",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_object_value() {
+        let is = r#"{ target: { nested: value } }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "\nFailed to parse `is:` argument to `derive`. The argument must be a string of the following shape: \"{ target_field_name: source_field_name }\".\n",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_fails_on_complex_path() {
+        let is = r#"{ target: source.field }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Err(
+            "\nFailed to parse `is:` argument to `derive`. The argument must be a string of the following shape: \"{ target_field_name: source_field_name }\".\n",
+        )
+        "#);
+    }
+
+    #[test]
+    fn extract_is_succeeds_on_null_keyword() {
+        let is = r#"{ target: null }"#;
+        let result = extract_is(is);
+        insta::assert_debug_snapshot!(result, @r#"
+        Ok(
+            SimpleIs {
+                fields: [
+                    SimpleIsField {
+                        input_field_name: "null",
+                        output_field_name: "target",
+                    },
+                ],
+            },
+        )
+        "#);
+    }
+}

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
@@ -4,6 +4,7 @@ pub(super) const OBJECT_DIRECTIVES: u32 = 58301;
 pub(super) const INPUT_OBJECT_DIRECTIVES: u32 = 58302;
 pub(super) const OUTPUT_FIELD_DIRECTIVES: u32 = 58301;
 pub(super) const INPUT_FIELD_DIRECTIVES: u32 = 58302;
+pub(super) const DERIVE: u32 = 58303;
 pub(super) const ENUM_DIRECTIVES: u32 = 58301;
 pub(super) const ENUM_VALUE_DIRECTIVES: u32 = 58301;
 

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package test.composite;
+
+service ProductService {
+  rpc GetProduct(GetProductRequest) returns (Product);
+  rpc CreateProduct(CreateProductRequest) returns (Product);
+  rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
+}
+
+// Test messages with composite schema entities
+message Product {
+  option (grafbase.graphql.derive) = {entity: "User", is: "{ id: user_id }"};
+  option (grafbase.graphql.derive) = {entity: "Category", is: "{ categoryId: category_id }"};
+  option (grafbase.graphql.derive) = {entity: "Shop", field: "shop_ref", is: "{ slug: shop }"};
+
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  // Basic usage - entity User with field id
+  string user_id = 4;
+  // With custom relation field name - these won't generate derive fields
+  string owner_id = 5;
+  string category_id = 6;
+  string shop = 7;
+  int32 store_id = 8;
+}
+
+message Review {
+  option (grafbase.graphql.derive) = {entity: "Product", is: "{ id: product_id }"};
+
+  string id = 1;
+  string content = 2;
+  // Test multiple references to same entity
+  string product_id = 3;
+  string reviewer_id = 4;
+}
+
+message GetProductRequest {
+  string id = 1;
+}
+
+message CreateProductRequest {
+  string name = 1;
+  string description = 2;
+  string user_id = 3;
+  string owner_id = 4;
+  string category_id = 5;
+}
+
+message ListProductsRequest {
+  int32 limit = 1;
+  string cursor = 2;
+}
+
+message ListProductsResponse {
+  repeated Product products = 1;
+  string next_cursor = 2;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.snap
@@ -1,0 +1,236 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.proto
+---
+#--- schema.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "test.composite.ProductService"
+        methods: [
+          {
+            name: "GetProduct"
+            inputType: ".test.composite.GetProductRequest"
+            outputType: ".test.composite.Product"
+          }
+          {
+            name: "CreateProduct"
+            inputType: ".test.composite.CreateProductRequest"
+            outputType: ".test.composite.Product"
+          }
+          {
+            name: "ListProducts"
+            inputType: ".test.composite.ListProductsRequest"
+            outputType: ".test.composite.ListProductsResponse"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.composite.Product"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "description"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "user_id"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "owner_id"
+            number: 5
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "category_id"
+            number: 6
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "shop"
+            number: 7
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "store_id"
+            number: 8
+            repeated: false
+            type: "int32"
+          }
+        ]
+      }
+      {
+        name: ".test.composite.GetProductRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.composite.CreateProductRequest"
+        fields: [
+          {
+            name: "name"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "description"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "user_id"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "owner_id"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "category_id"
+            number: 5
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.composite.ListProductsRequest"
+        fields: [
+          {
+            name: "limit"
+            number: 1
+            repeated: false
+            type: "int32"
+          }
+          {
+            name: "cursor"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.composite.ListProductsResponse"
+        fields: [
+          {
+            name: "products"
+            number: 1
+            repeated: true
+            type: ".test.composite.Product"
+          }
+          {
+            name: "next_cursor"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  test_composite_ProductService_GetProduct(input: test_composite_GetProductRequestInput): test_composite_Product @grpcMethod(service: "test.composite.ProductService", method: "GetProduct")
+  test_composite_ProductService_CreateProduct(input: test_composite_CreateProductRequestInput): test_composite_Product @grpcMethod(service: "test.composite.ProductService", method: "CreateProduct")
+  test_composite_ProductService_ListProducts(input: test_composite_ListProductsRequestInput): test_composite_ListProductsResponse @grpcMethod(service: "test.composite.ProductService", method: "ListProducts")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input test_composite_GetProductRequestInput {
+  id: String
+}
+
+input test_composite_CreateProductRequestInput {
+  name: String
+  description: String
+  user_id: String
+  owner_id: String
+  category_id: String
+}
+
+input test_composite_ListProductsRequestInput {
+  limit: Int
+  cursor: String
+}
+
+"""
+Test messages with composite schema entities
+"""
+type test_composite_Product {
+  id: String
+  name: String
+  description: String
+"""
+Basic usage - entity User with field id
+"""
+  user_id: String
+"""
+With custom relation field name - these won't generate derive fields
+"""
+  owner_id: String
+  category_id: String
+  shop: String
+  store_id: Int
+  user: User @derive @is(field: "{ id: user_id }")
+  category: Category @derive @is(field: "{ categoryId: category_id }")
+  shop_ref: Shop @derive @is(field: "{ slug: shop }")
+}
+
+type test_composite_ListProductsResponse {
+  products: [test_composite_Product!]
+  next_cursor: String
+}
+
+type Category @key(fields: "categoryId") {
+  categoryId: String
+}
+
+type Shop @key(fields: "slug") {
+  slug: String
+}
+
+type User @key(fields: "id") {
+  id: String
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package test.composite;
+
+service OrderService {
+  rpc GetOrder(GetOrderRequest) returns (Order);
+}
+
+message Order {
+  option (grafbase.graphql.derive) = {
+    entity: "CustomerAddress",
+    field: "delivery_address",
+    is: "{ customerId: customer_id addressId: address_id }"
+  };
+
+  string id = 1;
+  string description = 2;
+
+  // Composite key reference to CustomerAddress entity
+  string customer_id = 3;
+  string address_id = 4;
+
+  // This creates a reference using both fields
+  string dummy_composite = 5;
+}
+
+message GetOrderRequest {
+  string id = 1;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.snap
@@ -1,0 +1,104 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.proto
+---
+#--- schema.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "test.composite.OrderService"
+        methods: [
+          {
+            name: "GetOrder"
+            inputType: ".test.composite.GetOrderRequest"
+            outputType: ".test.composite.Order"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.composite.Order"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "description"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "customer_id"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "address_id"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "dummy_composite"
+            number: 5
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.composite.GetOrderRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  test_composite_OrderService_GetOrder(input: test_composite_GetOrderRequestInput): test_composite_Order @grpcMethod(service: "test.composite.OrderService", method: "GetOrder")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input test_composite_GetOrderRequestInput {
+  id: String
+}
+
+type test_composite_Order {
+  id: String
+  description: String
+"""
+Composite key reference to CustomerAddress entity
+"""
+  customer_id: String
+  address_id: String
+"""
+This creates a reference using both fields
+"""
+  dummy_composite: String
+  delivery_address: CustomerAddress @derive @is(field: "{ customerId: customer_id, addressId: address_id }")
+}
+
+type CustomerAddress @key(fields: "customerId addressId") {
+  customerId: String
+  addressId: String
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package test.composite;
+
+service OrderService {
+  rpc GetOrder(GetOrderRequest) returns (Order);
+}
+
+// Test message-level composite schema entity with composite key
+message Order {
+  option (grafbase.graphql.derive) = {
+    entity: "CustomerAddress",
+    field: "delivery_address",
+    is: "{ customerId: customer_id addressId: address_id }"
+  };
+
+  string id = 1;
+  string description = 2;
+  // Composite key reference to CustomerAddress entity
+  string customer_id = 3;
+  string address_id = 4;
+}
+
+// Test message-level composite schema entity with single key
+message Product {
+  option (grafbase.graphql.derive) = {
+    entity: "User",
+    field: "owner",
+    is: "{ id: user_id }"
+  };
+
+  string id = 1;
+  string name = 2;
+  string user_id = 3;
+}
+
+message GetOrderRequest {
+  string id = 1;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.snap
@@ -1,0 +1,97 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.proto
+---
+#--- schema.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "test.composite.OrderService"
+        methods: [
+          {
+            name: "GetOrder"
+            inputType: ".test.composite.GetOrderRequest"
+            outputType: ".test.composite.Order"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.composite.Order"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "description"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "customer_id"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "address_id"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.composite.GetOrderRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  test_composite_OrderService_GetOrder(input: test_composite_GetOrderRequestInput): test_composite_Order @grpcMethod(service: "test.composite.OrderService", method: "GetOrder")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input test_composite_GetOrderRequestInput {
+  id: String
+}
+
+"""
+Test message-level composite schema entity with composite key
+"""
+type test_composite_Order {
+  id: String
+  description: String
+"""
+Composite key reference to CustomerAddress entity
+"""
+  customer_id: String
+  address_id: String
+  delivery_address: CustomerAddress @derive @is(field: "{ customerId: customer_id, addressId: address_id }")
+}
+
+type CustomerAddress @key(fields: "customerId addressId") {
+  customerId: String
+  addressId: String
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package test.nodedup;
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc GetPost(GetPostRequest) returns (Post);
+  rpc GetProduct(GetProductRequest) returns (Product);
+}
+
+// This message is already rendered as output, so it shouldn't
+// be rendered again as an entity stub
+message User {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+}
+
+// This references User, but since User is already rendered,
+// we shouldn't create a duplicate User type
+message Post {
+  option (grafbase.graphql.derive) = {
+    entity: "test_nodedup_User",
+    field: "author",
+    is: "{ id: author_id }"
+  };
+
+  string id = 1;
+  string title = 2;
+  string content = 3;
+  string author_id = 4;
+}
+
+// This references a non-existent Category type, so it should
+// be rendered as an entity stub
+message Product {
+  option (grafbase.graphql.derive) = {
+    entity: "Category",
+    is: "{ id: category_id }"
+  };
+
+  string id = 1;
+  string name = 2;
+  string category_id = 3;
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message GetPostRequest {
+  string id = 1;
+}
+
+message GetProductRequest {
+  string id = 1;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.snap
@@ -1,0 +1,203 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.proto
+---
+#--- schema.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "test.nodedup.UserService"
+        methods: [
+          {
+            name: "GetUser"
+            inputType: ".test.nodedup.GetUserRequest"
+            outputType: ".test.nodedup.User"
+          }
+          {
+            name: "GetPost"
+            inputType: ".test.nodedup.GetPostRequest"
+            outputType: ".test.nodedup.Post"
+          }
+          {
+            name: "GetProduct"
+            inputType: ".test.nodedup.GetProductRequest"
+            outputType: ".test.nodedup.Product"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.nodedup.User"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "email"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.nodedup.Post"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "title"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "content"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "author_id"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.nodedup.Product"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "category_id"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.nodedup.GetUserRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.nodedup.GetPostRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.nodedup.GetProductRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  test_nodedup_UserService_GetUser(input: test_nodedup_GetUserRequestInput): test_nodedup_User @grpcMethod(service: "test.nodedup.UserService", method: "GetUser")
+  test_nodedup_UserService_GetPost(input: test_nodedup_GetPostRequestInput): test_nodedup_Post @grpcMethod(service: "test.nodedup.UserService", method: "GetPost")
+  test_nodedup_UserService_GetProduct(input: test_nodedup_GetProductRequestInput): test_nodedup_Product @grpcMethod(service: "test.nodedup.UserService", method: "GetProduct")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input test_nodedup_GetUserRequestInput {
+  id: String
+}
+
+input test_nodedup_GetPostRequestInput {
+  id: String
+}
+
+input test_nodedup_GetProductRequestInput {
+  id: String
+}
+
+"""
+This message is already rendered as output, so it shouldn't
+ be rendered again as an entity stub
+"""
+type test_nodedup_User {
+  id: String
+  name: String
+  email: String
+}
+
+"""
+This references User, but since User is already rendered,
+ we shouldn't create a duplicate User type
+"""
+type test_nodedup_Post {
+  id: String
+  title: String
+  content: String
+  author_id: String
+  author: test_nodedup_User @derive @is(field: "{ id: author_id }")
+}
+
+"""
+This references a non-existent Category type, so it should
+ be rendered as an entity stub
+"""
+type test_nodedup_Product {
+  id: String
+  name: String
+  category_id: String
+  category: Category @derive @is(field: "{ id: category_id }")
+}
+
+type Category @key(fields: "id") {
+  id: String
+}


### PR DESCRIPTION
You can now create federation-style entity references using the `composite_schemas_entity` option on messages. 

 - Automatically generates reference fields with `@derive` and `@is` directives
 - Creates stub entity types with `@key` directives if the target entity isn't already being rendered.
 - Supports custom relation field names with the `field` parameter
 - Enables entity references from a single id or multiple fields in federated schemas, including list of ids.

closes GB-9489