### PR TITLE
 protoc-gen-grafbase-subgraph: directives on method arguments 

### DIFF
--- a/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
+++ b/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
@@ -13,6 +13,12 @@
   - The `@is` directive maps the key field to the annotated field using format `@is(field: "{ <key_field_name>: <field_name> }")`
   - Enables cross-subgraph entity references in federated schemas
 
+- **Input argument directives support** added. You can now add GraphQL directives to RPC method input arguments using the `input_argument_directives` option:
+  - Use `option (grafbase.graphql.input_argument_directives) = "@constraint(minLength: 1)";` in method options
+  - Supports multiple directives in a single string, separated by spaces
+  - Works with both Query and Mutation fields
+  - Can be combined with existing method directives
+
 - **Multiple subgraphs support** added. Support for generating multiple GraphQL files based on service annotations:
 
   - Services can now have a `subgraph_name` option that maps them to different subgraph files

--- a/cli/protoc-gen-grafbase-subgraph/README.md
+++ b/cli/protoc-gen-grafbase-subgraph/README.md
@@ -97,6 +97,42 @@ enum Color {
 }
 ```
 
+### Adding directives on RPC method input arguments
+
+You can add GraphQL directives to the input argument of RPC methods using the `input_argument_directives` option:
+
+```protobuf
+import "grafbase/options.proto";
+
+service UserService {
+  rpc CreateUser(CreateUserRequest) returns (User) {
+    option (grafbase.graphql.input_argument_directives) = "@constraint(minLength: 1)";
+  }
+
+  rpc UpdateUser(UpdateUserRequest) returns (User) {
+    option (grafbase.graphql.input_argument_directives) = "@constraint(minLength: 1) @auth(rules: [{allow: owner}])";
+  }
+
+  rpc SearchUsers(SearchUsersRequest) returns (SearchUsersResponse) {
+    option (grafbase.graphql.is_query) = true;
+    option (grafbase.graphql.input_argument_directives) = "@constraint(maxLength: 100)";
+  }
+}
+```
+
+This will generate GraphQL with directives on the input arguments:
+
+```graphql
+type Query {
+  UserService_SearchUsers(input: SearchUsersRequestInput @constraint(maxLength: 100)): SearchUsersResponse @grpcMethod(...)
+}
+
+type Mutation {
+  UserService_CreateUser(input: CreateUserRequestInput @constraint(minLength: 1)): User @grpcMethod(...)
+  UserService_UpdateUser(input: UpdateUserRequestInput @constraint(minLength: 1) @auth(rules: [{allow: owner}])): User @grpcMethod(...)
+}
+```
+
 ### Adding schema directives
 
 You can add directives to the GraphQL schema extension using the `schema_directives` option at the service level:

--- a/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
+++ b/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
@@ -40,4 +40,5 @@ extend google.protobuf.MethodOptions {
   optional string directives = 58301;
   optional bool is_query = 58302;
   optional bool is_mutation = 58303;
+  optional string input_argument_directives = 58304;
 }

--- a/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
@@ -119,6 +119,10 @@ fn render_method_field(
 
     render_input_field_type(schema, &method.input_type, false, f)?;
 
+    if let Some(directives) = method.input_argument_directives.as_deref() {
+        write!(f, " {directives}")?;
+    }
+
     f.write_str("): ")?;
 
     render_output_field_type(schema, &method.output_type, false, f)?;

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
@@ -97,6 +97,7 @@ pub(crate) struct ProtoMethod {
     pub(crate) is_query: Option<bool>,
     pub(crate) is_mutation: Option<bool>,
     pub(crate) directives: Option<String>,
+    pub(crate) input_argument_directives: Option<String>,
 }
 
 impl PartialOrd for ProtoMethod {

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
@@ -162,6 +162,7 @@ fn translate_service(
             is_query: None,
             is_mutation: None,
             directives: None,
+            input_argument_directives: None,
         };
 
         extract_method_graphql_options_from_options(method, &mut proto_method);
@@ -569,7 +570,18 @@ fn extract_method_graphql_options_from_options(
             _ => None,
         });
 
+    let input_argument_directives = method
+        .options
+        .special_fields
+        .unknown_fields()
+        .get(INPUT_ARGUMENT_DIRECTIVES)
+        .and_then(|unknown_value_ref| match unknown_value_ref {
+            protobuf::UnknownValueRef::LengthDelimited(items) => Some(str::from_utf8(items).unwrap().to_owned()),
+            _ => None,
+        });
+
     proto_method.directives = directives;
+    proto_method.input_argument_directives = input_argument_directives;
     proto_method.is_query = is_query;
     proto_method.is_mutation = is_mutation;
 }

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
@@ -16,3 +16,4 @@ pub(super) const SCHEMA_DIRECTIVES: u32 = 58304;
 pub(super) const DIRECTIVES: u32 = 58301;
 pub(super) const IS_QUERY: u32 = 58302;
 pub(super) const IS_MUTATION: u32 = 58303;
+pub(super) const INPUT_ARGUMENT_DIRECTIVES: u32 = 58304;

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/input_argument_directives.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/input_argument_directives.proto
@@ -1,0 +1,125 @@
+//!file:grafbase/options.proto
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+package grafbase.graphql;
+
+message CompositeSchemaEntity {
+  optional string entity = 1;
+  optional string field = 2;
+  optional string field_name = 3;
+}
+
+extend google.protobuf.MessageOptions {
+  optional string object_directives = 58301;
+  optional string input_object_directives = 58302;
+}
+
+extend google.protobuf.FieldOptions {
+  optional string output_field_directives = 58301;
+  optional string input_field_directives = 58302;
+  optional CompositeSchemaEntity composite_schemas_entity = 58303;
+}
+
+extend google.protobuf.EnumOptions {
+  optional string enum_directives = 58301;
+}
+
+extend google.protobuf.EnumValueOptions {
+  optional string enum_value_directives = 58301;
+}
+
+extend google.protobuf.ServiceOptions {
+  optional bool default_to_query_fields = 58301;
+  optional bool default_to_mutation_fields = 58302;
+  optional string subgraph_name = 58303;
+  optional string schema_directives = 58304;
+}
+
+extend google.protobuf.MethodOptions {
+  optional string directives = 58301;
+  optional bool is_query = 58302;
+  optional bool is_mutation = 58303;
+  optional string input_argument_directives = 58304;
+}
+
+//!file:input_argument_directives.proto
+syntax = "proto3";
+
+import "grafbase/options.proto";
+
+package test.input_arg_directives;
+
+// Test service with input argument directives on methods
+service UserService {
+  // Method with a single directive on input argument
+  rpc CreateUser(CreateUserRequest) returns (User) {
+    option (grafbase.graphql.input_argument_directives) = "@constraint(minLength: 1)";
+  }
+
+  // Method with multiple directives on input argument
+  rpc UpdateUser(UpdateUserRequest) returns (User) {
+    option (grafbase.graphql.input_argument_directives) = "@constraint(minLength: 1) @auth(rules: [{allow: owner}])";
+  }
+
+  // Method with no input argument directives
+  rpc GetUser(GetUserRequest) returns (User) {
+    option (grafbase.graphql.is_query) = true;
+  }
+
+  // Method with both input argument directives and method directives
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
+    option (grafbase.graphql.input_argument_directives) = "@constraint(format: \"uuid\")";
+    option (grafbase.graphql.directives) = "@deprecated(reason: \"Use removeUser instead\")";
+  }
+}
+
+// Another service to test different patterns
+service AdminService {
+  // Query method with validation directive
+  rpc SearchUsers(SearchUsersRequest) returns (SearchUsersResponse) {
+    option (grafbase.graphql.is_query) = true;
+    option (grafbase.graphql.input_argument_directives) = "@constraint(maxLength: 100)";
+  }
+}
+
+// Messages
+message User {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+}
+
+message CreateUserRequest {
+  string name = 1;
+  string email = 2;
+}
+
+message UpdateUserRequest {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message DeleteUserRequest {
+  string id = 1;
+}
+
+message DeleteUserResponse {
+  bool success = 1;
+}
+
+message SearchUsersRequest {
+  string query = 1;
+  int32 limit = 2;
+}
+
+message SearchUsersResponse {
+  repeated User users = 1;
+  int32 total_count = 2;
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/input_argument_directives.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/input_argument_directives.snap
@@ -1,0 +1,253 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/input_argument_directives.proto
+---
+#--- schema.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "test.input_arg_directives.UserService"
+        methods: [
+          {
+            name: "CreateUser"
+            inputType: ".test.input_arg_directives.CreateUserRequest"
+            outputType: ".test.input_arg_directives.User"
+          }
+          {
+            name: "UpdateUser"
+            inputType: ".test.input_arg_directives.UpdateUserRequest"
+            outputType: ".test.input_arg_directives.User"
+          }
+          {
+            name: "GetUser"
+            inputType: ".test.input_arg_directives.GetUserRequest"
+            outputType: ".test.input_arg_directives.User"
+          }
+          {
+            name: "DeleteUser"
+            inputType: ".test.input_arg_directives.DeleteUserRequest"
+            outputType: ".test.input_arg_directives.DeleteUserResponse"
+          }
+        ]
+      }
+      {
+        name: "test.input_arg_directives.AdminService"
+        methods: [
+          {
+            name: "SearchUsers"
+            inputType: ".test.input_arg_directives.SearchUsersRequest"
+            outputType: ".test.input_arg_directives.SearchUsersResponse"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.input_arg_directives.User"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "email"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.CreateUserRequest"
+        fields: [
+          {
+            name: "name"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "email"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.UpdateUserRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "name"
+            number: 2
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "email"
+            number: 3
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.GetUserRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.DeleteUserRequest"
+        fields: [
+          {
+            name: "id"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.DeleteUserResponse"
+        fields: [
+          {
+            name: "success"
+            number: 1
+            repeated: false
+            type: "bool"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.SearchUsersRequest"
+        fields: [
+          {
+            name: "query"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "limit"
+            number: 2
+            repeated: false
+            type: "int32"
+          }
+        ]
+      }
+      {
+        name: ".test.input_arg_directives.SearchUsersResponse"
+        fields: [
+          {
+            name: "users"
+            number: 1
+            repeated: true
+            type: ".test.input_arg_directives.User"
+          }
+          {
+            name: "total_count"
+            number: 2
+            repeated: false
+            type: "int32"
+          }
+        ]
+      }
+    ]
+  )
+
+type Query {
+"""
+Method with no input argument directives
+"""
+  test_input_arg_directives_UserService_GetUser(input: test_input_arg_directives_GetUserRequestInput): test_input_arg_directives_User @grpcMethod(service: "test.input_arg_directives.UserService", method: "GetUser")
+"""
+Query method with validation directive
+"""
+  test_input_arg_directives_AdminService_SearchUsers(input: test_input_arg_directives_SearchUsersRequestInput @constraint(maxLength: 100)): test_input_arg_directives_SearchUsersResponse @grpcMethod(service: "test.input_arg_directives.AdminService", method: "SearchUsers")
+}
+
+type Mutation {
+"""
+Method with a single directive on input argument
+"""
+  test_input_arg_directives_UserService_CreateUser(input: test_input_arg_directives_CreateUserRequestInput @constraint(minLength: 1)): test_input_arg_directives_User @grpcMethod(service: "test.input_arg_directives.UserService", method: "CreateUser")
+"""
+Method with multiple directives on input argument
+"""
+  test_input_arg_directives_UserService_UpdateUser(input: test_input_arg_directives_UpdateUserRequestInput @constraint(minLength: 1) @auth(rules: [{allow: owner}])): test_input_arg_directives_User @grpcMethod(service: "test.input_arg_directives.UserService", method: "UpdateUser")
+"""
+Method with both input argument directives and method directives
+"""
+  test_input_arg_directives_UserService_DeleteUser(input: test_input_arg_directives_DeleteUserRequestInput @constraint(format: "uuid")): test_input_arg_directives_DeleteUserResponse @grpcMethod(service: "test.input_arg_directives.UserService", method: "DeleteUser") @deprecated(reason: "Use removeUser instead")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+input test_input_arg_directives_CreateUserRequestInput {
+  name: String
+  email: String
+}
+
+input test_input_arg_directives_UpdateUserRequestInput {
+  id: String
+  name: String
+  email: String
+}
+
+input test_input_arg_directives_GetUserRequestInput {
+  id: String
+}
+
+input test_input_arg_directives_DeleteUserRequestInput {
+  id: String
+}
+
+input test_input_arg_directives_SearchUsersRequestInput {
+  query: String
+  limit: Int
+}
+
+"""
+Messages
+"""
+type test_input_arg_directives_User {
+  id: String
+  name: String
+  email: String
+}
+
+type test_input_arg_directives_DeleteUserResponse {
+  success: Boolean
+}
+
+type test_input_arg_directives_SearchUsersResponse {
+  users: [test_input_arg_directives_User!]
+  total_count: Int
+}


### PR DESCRIPTION
Adds input argument directives support. You can now add GraphQL directives to RPC method input arguments using the `input_argument_directives` option:
  - Use `option (grafbase.graphql.input_argument_directives) = "@constraint(minLength: 1)";` in method options
  - Supports multiple directives in a single string, separated by spaces

The motivation for this is `@is` for composite schema lookups.