### PR TITLE
protoc-gen-grafbase-subgraph: take optional into account for scalars

### DIFF
--- a/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
+++ b/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ### Added
 
-- **Input argument directives** added. You can now add GraphQL directives to RPC method input arguments using the `argument_directives` option on methods.
+- **Input argument directives** added. You can now add GraphQL directives to RPC method input argument, that corresponds to the input of the RPC method, using the `argument_directives` option on methods.
+
+- **Proto3 optional field support** added. The generator now properly handles proto3 optional fields:
+  - Non-optional scalar and enum fields in proto3 are rendered as non-nullable (`Type!`) in GraphQL output types
+  - Optional scalar and enum fields are rendered as nullable (`Type`) in GraphQL output types
+  - Message type fields are always nullable regardless of the optional flag
+  - Input types remain nullable for all fields
+  - The generator now declares support for `FEATURE_PROTO3_OPTIONAL` to work with proto3 files containing optional fields
 
 - **Composite schema entity references with @derive** added. You can now create federation-style entity references using the `derive` option on messages:
   - Use `option (grafbase.graphql.derive) = {entity: "User", is: "{ id: user_id }"};` on fields

--- a/cli/protoc-gen-grafbase-subgraph/README.md
+++ b/cli/protoc-gen-grafbase-subgraph/README.md
@@ -178,20 +178,20 @@ import "grafbase/options.proto";
 
 message Product {
   // Basic usage: creates a user field that references User entity by id
-  (grafbase.graphql.derive) = {
+  option (grafbase.graphql.derive) = {
     entity: "User",
     is: "{ id: user_id }"
   };
 
   // Custom relation field name: creates an owner field instead of user
-  (grafbase.graphql.derive) = {
+  option (grafbase.graphql.derive) = {
     entity: "User",
     field: "owner"
     is: "{ id: owner_id }"
   };
 
   // Reference by non-id field
-  (grafbase.graphql.composite_schemas_entity) = {
+  option (grafbase.graphql.composite_schemas_entity) = {
     entity: "Shop",
     is: "{ slug: shop_slug }"
   };

--- a/cli/protoc-gen-grafbase-subgraph/src/main.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/main.rs
@@ -5,7 +5,7 @@ mod schema;
 mod translate_schema;
 
 use protobuf::plugin::{CodeGeneratorRequest, CodeGeneratorResponse, code_generator_response::File};
-use protobuf::{CodedOutputStream, Message};
+use protobuf::{CodedOutputStream, Enum, Message};
 use render_graphql_sdl::{render_graphql_sdl, render_graphql_sdl_filtered};
 use std::{
     env,
@@ -33,6 +33,10 @@ fn generate(raw_request: &[u8]) -> CodeGeneratorResponse {
     let translated_schema = translate_schema(request);
 
     let mut response = CodeGeneratorResponse::new();
+
+    response.set_supported_features(
+        protobuf::plugin::code_generator_response::Feature::FEATURE_PROTO3_OPTIONAL.value() as u64,
+    );
 
     if translated_schema.services.is_empty() {
         return response;

--- a/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/graphql_types.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/graphql_types.rs
@@ -96,7 +96,7 @@ fn render_message(
         if input {
             render_input_field_type(schema, &field.r#type, field.repeated, f)?;
         } else {
-            render_output_field_type(schema, &field.r#type, field.repeated, true, f)?;
+            render_output_field_type(schema, &field.r#type, field.repeated, field.optional, f)?;
         }
 
         let field_directives = if input {
@@ -356,7 +356,7 @@ fn render_entity_types(
                     let field_found = message_id.fields(schema).find(|f| f.name == is_field.input_field_name);
 
                     if let Some(field) = field_found {
-                        render_output_field_type(schema, &field.r#type, false, true, f)?;
+                        render_output_field_type(schema, &field.r#type, false, field.optional, f)?;
                     } else {
                         // Default to String if field not found
                         f.write_str("String")?;

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
@@ -54,6 +54,7 @@ pub(crate) struct ProtoField {
     pub(crate) r#type: FieldType,
     pub(crate) number: u16,
     pub(crate) repeated: bool,
+    pub(crate) optional: bool,
     pub(crate) description: Option<String>,
     pub(crate) input_field_directives: Option<String>,
     pub(crate) output_field_directives: Option<String>,

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema.rs
@@ -333,6 +333,7 @@ fn translate_fields(
         };
 
         let repeated = field.label.unwrap_or_default().enum_value_or_default() == Label::LABEL_REPEATED;
+        let optional = field.proto3_optional();
 
         let mut proto_field = ProtoField {
             message_id,
@@ -340,6 +341,7 @@ fn translate_fields(
             r#type,
             number,
             repeated,
+            optional,
             description,
             input_field_directives: None,
             output_field_directives: None,

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/argument_directives.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/argument_directives.snap
@@ -238,16 +238,16 @@ input test_input_arg_directives_SearchUsersRequestInput {
 Messages
 """
 type test_input_arg_directives_User {
-  id: String
-  name: String
-  email: String
+  id: String!
+  name: String!
+  email: String!
 }
 
 type test_input_arg_directives_DeleteUserResponse {
-  success: Boolean
+  success: Boolean!
 }
 
 type test_input_arg_directives_SearchUsersResponse {
   users: [test_input_arg_directives_User!]
-  total_count: Int
+  total_count: Int!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/birds_nested.snap
@@ -326,32 +326,32 @@ input GetBirdsRequestInput {
 }
 
 type Bird {
-  name: String
-  scientific_name: String
-  weight_in_kg: Float
-  is_migratory: Boolean
-  size: Bird_Size
-  primary_habitat: Bird_Habitat
+  name: String!
+  scientific_name: String!
+  weight_in_kg: Float!
+  is_migratory: Boolean!
+  size: Bird_Size!
+  primary_habitat: Bird_Habitat!
   secondary_habitats: [Bird_Habitat!]
   diet: Bird_Diet
   plumage: Bird_Plumage
-  average_lifespan_years: Int
+  average_lifespan_years: Int!
   conservation_status: [String!]
 }
 
 type Bird_Diet {
-  carnivorous: Boolean
-  herbivorous: Boolean
-  omnivorous: Boolean
+  carnivorous: Boolean!
+  herbivorous: Boolean!
+  omnivorous: Boolean!
   favorite_foods: [String!]
-  feeding_style: Bird_Diet_FeedingStyle
+  feeding_style: Bird_Diet_FeedingStyle!
 }
 
 type Bird_Plumage {
-  primary_color: String
+  primary_color: String!
   secondary_colors: [String!]
-  has_distinct_mating_colors: Boolean
-  pattern: Bird_Plumage_Pattern
+  has_distinct_mating_colors: Boolean!
+  pattern: Bird_Plumage_Pattern!
 }
 
 type GetBirdsResponse {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity.snap
@@ -199,20 +199,20 @@ input test_composite_ListProductsRequestInput {
 Test messages with composite schema entities
 """
 type test_composite_Product {
-  id: String
-  name: String
-  description: String
+  id: String!
+  name: String!
+  description: String!
 """
 Basic usage - entity User with field id
 """
-  user_id: String
+  user_id: String!
 """
 With custom relation field name - these won't generate derive fields
 """
-  owner_id: String
-  category_id: String
-  shop: String
-  store_id: Int
+  owner_id: String!
+  category_id: String!
+  shop: String!
+  store_id: Int!
   user: User @derive @is(field: "{ id: user_id }")
   category: Category @derive @is(field: "{ categoryId: category_id }")
   shop_ref: Shop @derive @is(field: "{ slug: shop }")
@@ -220,17 +220,17 @@ With custom relation field name - these won't generate derive fields
 
 type test_composite_ListProductsResponse {
   products: [test_composite_Product!]
-  next_cursor: String
+  next_cursor: String!
 }
 
 type Category @key(fields: "categoryId") {
-  categoryId: String
+  categoryId: String!
 }
 
 type Shop @key(fields: "slug") {
-  slug: String
+  slug: String!
 }
 
 type User @key(fields: "id") {
-  id: String
+  id: String!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_composite.snap
@@ -84,21 +84,21 @@ input test_composite_GetOrderRequestInput {
 }
 
 type test_composite_Order {
-  id: String
-  description: String
+  id: String!
+  description: String!
 """
 Composite key reference to CustomerAddress entity
 """
-  customer_id: String
-  address_id: String
+  customer_id: String!
+  address_id: String!
 """
 This creates a reference using both fields
 """
-  dummy_composite: String
+  dummy_composite: String!
   delivery_address: CustomerAddress @derive @is(field: "{ customerId: customer_id, addressId: address_id }")
 }
 
 type CustomerAddress @key(fields: "customerId addressId") {
-  customerId: String
-  addressId: String
+  customerId: String!
+  addressId: String!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_message_level.snap
@@ -81,17 +81,17 @@ input test_composite_GetOrderRequestInput {
 Test message-level composite schema entity with composite key
 """
 type test_composite_Order {
-  id: String
-  description: String
+  id: String!
+  description: String!
 """
 Composite key reference to CustomerAddress entity
 """
-  customer_id: String
-  address_id: String
+  customer_id: String!
+  address_id: String!
   delivery_address: CustomerAddress @derive @is(field: "{ customerId: customer_id, addressId: address_id }")
 }
 
 type CustomerAddress @key(fields: "customerId addressId") {
-  customerId: String
-  addressId: String
+  customerId: String!
+  addressId: String!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_entity_no_duplicate.snap
@@ -170,9 +170,9 @@ This message is already rendered as output, so it shouldn't
  be rendered again as an entity stub
 """
 type test_nodedup_User {
-  id: String
-  name: String
-  email: String
+  id: String!
+  name: String!
+  email: String!
 }
 
 """
@@ -180,10 +180,10 @@ This references User, but since User is already rendered,
  we shouldn't create a duplicate User type
 """
 type test_nodedup_Post {
-  id: String
-  title: String
-  content: String
-  author_id: String
+  id: String!
+  title: String!
+  content: String!
+  author_id: String!
   author: test_nodedup_User @derive @is(field: "{ id: author_id }")
 }
 
@@ -192,12 +192,12 @@ This references a non-existent Category type, so it should
  be rendered as an entity stub
 """
 type test_nodedup_Product {
-  id: String
-  name: String
-  category_id: String
+  id: String!
+  name: String!
+  category_id: String!
   category: Category @derive @is(field: "{ id: category_id }")
 }
 
 type Category @key(fields: "id") {
-  id: String
+  id: String!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/echo.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/echo.snap
@@ -101,5 +101,5 @@ input grpc_examples_echo_EchoRequestInput {
 EchoResponse is the response for echo.
 """
 type grpc_examples_echo_EchoResponse {
-  message: String
+  message: String!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/inventory.snap
@@ -113,7 +113,7 @@ input test_inventory_SearchRequestInput @oneOf {
 }
 
 type test_inventory_SearchResponse @key(fields: "id") {
-  id: String @deprecated(reason: "Use IDV2")
+  id: String! @deprecated(reason: "Use IDV2")
 }
 
 enum test_inventory_Color @deprecated(reason: "Use ColorV2") {

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/multi_subgraph.snap
@@ -106,10 +106,10 @@ input example_CreateOrderRequestInput {
 }
 
 type example_Order {
-  id: String
-  user_id: String
+  id: String!
+  user_id: String!
   product_ids: [String!]
-  total: Float
+  total: Float!
 }
 
 #--- products.graphql ---#
@@ -267,15 +267,15 @@ input example_ListProductsRequestInput {
 }
 
 type example_Product {
-  id: String
-  name: String
-  price: Float
-  owner_id: String
+  id: String!
+  name: String!
+  price: Float!
+  owner_id: String!
 }
 
 type example_ListProductsResponse {
   products: [example_Product!]
-  next_cursor: String
+  next_cursor: String!
 }
 
 #--- users.graphql ---#
@@ -423,12 +423,12 @@ input example_ListUsersRequestInput {
 Shared types
 """
 type example_User {
-  id: String
-  name: String
-  email: String
+  id: String!
+  name: String!
+  email: String!
 }
 
 type example_ListUsersResponse {
   users: [example_User!]
-  next_cursor: String
+  next_cursor: String!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/optional_fields.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/optional_fields.proto
@@ -1,0 +1,44 @@
+//!file:optional_fields.proto
+syntax = "proto3";
+
+package test.optional;
+
+// Test message with a mix of optional and non-optional fields
+message TestMessage {
+  // Non-optional scalar fields (should render as Type! in output types, Type in input types)
+  string required_string = 1;
+  int32 required_int = 2;
+  bool required_bool = 3;
+  
+  // Optional scalar fields (should render as Type in both output and input types)
+  optional string optional_string = 4;
+  optional int32 optional_int = 5;
+  optional bool optional_bool = 6;
+  
+  // Repeated field (should render as [Type!])
+  repeated string repeated_string = 7;
+  
+  // Message type field (should always be nullable)
+  NestedMessage nested_message = 8;
+  
+  // Optional message type field (should still be nullable)
+  optional NestedMessage optional_nested_message = 9;
+  
+  // Enum fields (non-optional renders as Type! in output types, Type in input types)
+  TestEnum required_enum = 10;
+  optional TestEnum optional_enum = 11;
+}
+
+message NestedMessage {
+  string value = 1;
+}
+
+enum TestEnum {
+  UNKNOWN = 0;
+  FIRST = 1;
+  SECOND = 2;
+}
+
+service TestService {
+  rpc GetTest(TestMessage) returns (TestMessage) {}
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/optional_fields.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/optional_fields.snap
@@ -1,0 +1,221 @@
+---
+source: cli/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: combined_output
+input_file: cli/protoc-gen-grafbase-subgraph/tests/testcases/optional_fields.proto
+---
+#--- schema.graphql ---#
+
+extend schema
+  @link(url: "https://grafbase.com/extensions/grpc/0.2.0", import: ["@protoServices", "@protoEnums", "@protoMessages", "@grpcMethod"])
+  @protoServices(
+    definitions: [
+      {
+        name: "test.optional.TestService"
+        methods: [
+          {
+            name: "GetTest"
+            inputType: ".test.optional.TestMessage"
+            outputType: ".test.optional.TestMessage"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    definitions: [
+      {
+        name: ".test.optional.TestMessage"
+        fields: [
+          {
+            name: "required_string"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "required_int"
+            number: 2
+            repeated: false
+            type: "int32"
+          }
+          {
+            name: "required_bool"
+            number: 3
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "optional_string"
+            number: 4
+            repeated: false
+            type: "string"
+          }
+          {
+            name: "optional_int"
+            number: 5
+            repeated: false
+            type: "int32"
+          }
+          {
+            name: "optional_bool"
+            number: 6
+            repeated: false
+            type: "bool"
+          }
+          {
+            name: "repeated_string"
+            number: 7
+            repeated: true
+            type: "string"
+          }
+          {
+            name: "nested_message"
+            number: 8
+            repeated: false
+            type: ".test.optional.NestedMessage"
+          }
+          {
+            name: "optional_nested_message"
+            number: 9
+            repeated: false
+            type: ".test.optional.NestedMessage"
+          }
+          {
+            name: "required_enum"
+            number: 10
+            repeated: false
+            type: ".test.optional.TestEnum"
+          }
+          {
+            name: "optional_enum"
+            number: 11
+            repeated: false
+            type: ".test.optional.TestEnum"
+          }
+        ]
+      }
+      {
+        name: ".test.optional.NestedMessage"
+        fields: [
+          {
+            name: "value"
+            number: 1
+            repeated: false
+            type: "string"
+          }
+        ]
+      }
+    ]
+  )
+  @protoEnums(
+    definitions: [
+      {
+        name: ".test.optional.TestEnum"
+        values: [
+          {
+            name: "UNKNOWN"
+            number: 0
+          }
+          {
+            name: "FIRST"
+            number: 1
+          }
+          {
+            name: "SECOND"
+            number: 2
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  test_optional_TestService_GetTest(input: test_optional_TestMessageInput): test_optional_TestMessage @grpcMethod(service: "test.optional.TestService", method: "GetTest")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+"""
+Test message with a mix of optional and non-optional fields
+"""
+input test_optional_TestMessageInput {
+"""
+Non-optional scalar fields (should render as Type! in output types, Type in input types)
+"""
+  required_string: String
+  required_int: Int
+  required_bool: Boolean
+"""
+Optional scalar fields (should render as Type in both output and input types)
+"""
+  optional_string: String
+  optional_int: Int
+  optional_bool: Boolean
+"""
+Repeated field (should render as [Type!])
+"""
+  repeated_string: [String!]
+"""
+Message type field (should always be nullable)
+"""
+  nested_message: test_optional_NestedMessageInput
+"""
+Optional message type field (should still be nullable)
+"""
+  optional_nested_message: test_optional_NestedMessageInput
+"""
+Enum fields (non-optional renders as Type! in output types, Type in input types)
+"""
+  required_enum: test_optional_TestEnum
+  optional_enum: test_optional_TestEnum
+}
+
+input test_optional_NestedMessageInput {
+  value: String
+}
+
+"""
+Test message with a mix of optional and non-optional fields
+"""
+type test_optional_TestMessage {
+"""
+Non-optional scalar fields (should render as Type! in output types, Type in input types)
+"""
+  required_string: String!
+  required_int: Int!
+  required_bool: Boolean!
+"""
+Optional scalar fields (should render as Type in both output and input types)
+"""
+  optional_string: String
+  optional_int: Int
+  optional_bool: Boolean
+"""
+Repeated field (should render as [Type!])
+"""
+  repeated_string: [String!]
+"""
+Message type field (should always be nullable)
+"""
+  nested_message: test_optional_NestedMessage
+"""
+Optional message type field (should still be nullable)
+"""
+  optional_nested_message: test_optional_NestedMessage
+"""
+Enum fields (non-optional renders as Type! in output types, Type in input types)
+"""
+  required_enum: test_optional_TestEnum!
+  optional_enum: test_optional_TestEnum
+}
+
+type test_optional_NestedMessage {
+  value: String!
+}
+
+enum test_optional_TestEnum {
+  UNKNOWN,
+  FIRST,
+  SECOND,
+}

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/routeguide.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/routeguide.snap
@@ -228,8 +228,8 @@ Points are represented as latitude-longitude pairs in the E7 representation
  the range +/- 180 degrees (inclusive).
 """
 type routeguide_Point {
-  latitude: Int
-  longitude: Int
+  latitude: Int!
+  longitude: Int!
 }
 
 """
@@ -241,7 +241,7 @@ type routeguide_Feature {
 """
 The name of the feature.
 """
-  name: String
+  name: String!
 """
 The point where the feature is detected.
 """
@@ -259,7 +259,7 @@ The location from which the message is sent.
 """
 The message to be sent.
 """
-  message: String
+  message: String!
 }
 
 """
@@ -273,17 +273,17 @@ type routeguide_RouteSummary {
 """
 The number of points received.
 """
-  point_count: Int
+  point_count: Int!
 """
 The number of known features passed while traversing the route.
 """
-  feature_count: Int
+  feature_count: Int!
 """
 The distance covered in metres.
 """
-  distance: Int
+  distance: Int!
 """
 The duration of the traversal in seconds.
 """
-  elapsed_time: Int
+  elapsed_time: Int!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/schema_directives.snap
@@ -114,11 +114,11 @@ input test_schema_DeleteItemRequestInput {
 Messages
 """
 type test_schema_Item {
-  id: String
-  name: String
-  description: String
+  id: String!
+  name: String!
+  description: String!
 }
 
 type test_schema_DeleteItemResponse {
-  success: Boolean
+  success: Boolean!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/shared_subgraphs.snap
@@ -119,12 +119,12 @@ input example_LoginRequestInput {
 }
 
 type example_User {
-  id: String
-  name: String
+  id: String!
+  name: String!
 }
 
 type example_LoginResponse {
-  token: String
+  token: String!
   user: example_User
 }
 
@@ -197,7 +197,7 @@ input example_GetProductRequestInput {
 }
 
 type example_Product {
-  id: String
-  name: String
-  price: Float
+  id: String!
+  name: String!
+  price: Float!
 }

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/taqueria.snap
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/taqueria.snap
@@ -576,18 +576,18 @@ input taqueria_DailySalesRequestInput {
 Menu item message
 """
 type taqueria_MenuItem {
-  id: String
-  name: String
+  id: String!
+  name: String!
 """
 The price of the item in €.
 """
-  price: Float
-  description: String
-  meat: taqueria_MeatType
-  spice_level: taqueria_SpiceLevel
+  price: Float!
+  description: String!
+  meat: taqueria_MeatType!
+  spice_level: taqueria_SpiceLevel!
   toppings: [String!]
-  vegetarian: Boolean
-  vegan: Boolean
+  vegetarian: Boolean!
+  vegan: Boolean!
 }
 
 """
@@ -601,25 +601,25 @@ type taqueria_MenuResponse {
 Order response
 """
 type taqueria_OrderResponse {
-  order_id: String
-  estimated_ready_time: String
-  total_amount: Float
+  order_id: String!
+  estimated_ready_time: String!
+  total_amount: Float!
 }
 
 type taqueria_OrderStatusResponse {
-  order_id: String
-  status: taqueria_OrderStatus
-  status_updated_at: String
-  estimated_completion_time: String
+  order_id: String!
+  status: taqueria_OrderStatus!
+  status_updated_at: String!
+  estimated_completion_time: String!
 }
 
 """
 Daily sales response
 """
 type taqueria_DailySalesResponse {
-  date: String
-  total_orders: Int
-  total_revenue: Float
+  date: String!
+  total_orders: Int!
+  total_revenue: Float!
 """
 Map of menu_item_id to quantity sold
 """
@@ -628,13 +628,13 @@ Map of menu_item_id to quantity sold
 }
 
 type taqueria_DailySalesResponse_ItemsSoldEntry {
-  key: String
-  value: Int
+  key: String!
+  value: Int!
 }
 
 type taqueria_DailySalesResponse_MeatTypeCountsEntry {
-  key: Int
-  value: Int
+  key: Int!
+  value: Int!
 }
 
 """


### PR DESCRIPTION
Scalar and enum fields are required by default now, except those marked explicitly as optional. Message fields are always optional.