### PR TITLE
protoc-gen-grafbase-subgraph: break out lookup.argument_is

### DIFF
--- a/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
+++ b/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - **Composite schemas shortcuts** added. New protobuf options for simplified composite schemas directives:
   - `key` option generates `@key` directives on types
-  - `lookup` option generates `@lookup` directive with optional `@is` mapping
+  - `lookup` option generates `@lookup` directive on RPC methods
+  - `argument_is` option on RPC methods generates `@is` directive on the input argument - a shortcut for `grafbase.graphql.argument_directives = "@is(field: \"...\")"`
   - `join_field` option generates fields with `@require` and `@grpcMethod` directives, with proper type resolution
 
 - **Input argument directives** added. You can now add GraphQL directives to RPC method input argument, that corresponds to the input of the RPC method, using the `argument_directives` option on methods.

--- a/cli/protoc-gen-grafbase-subgraph/README.md
+++ b/cli/protoc-gen-grafbase-subgraph/README.md
@@ -310,14 +310,41 @@ type User @key(fields: "id") @key(fields: "alias email") {
 
 ### Lookup
 
-This is a shortcut for the `@link`, `@lookup` and `@is` directives needed to define a lookup field:
+This is a shortcut for the `@link` and `@lookup` directives needed to define a lookup field:
 
 ```proto
 service MyService {
   option (grafbase.graphql.default_to_query_fields) = true;
 
   rpc GetUser (GetUserRequest) returns (GetUserResponse) {
-    option (grafbase.graphql.lookup) = { argument_is: "{ user_id: user.id }" };
+    option (grafbase.graphql.lookup) = {};
+  }
+}
+```
+
+Will generate:
+
+```graphql
+extend schema @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup"])
+
+# ...
+
+type Query {
+  GetUser(input: GetUserRequest) @lookup
+}
+```
+
+### Argument @is directive
+
+The `argument_is` option is a shortcut for adding an `@is` directive to RPC method input arguments. It's equivalent to using `argument_directives` with `@is(field: "...")`:
+
+```proto
+service MyService {
+  option (grafbase.graphql.default_to_query_fields) = true;
+
+  rpc GetUser (GetUserRequest) returns (GetUserResponse) {
+    option (grafbase.graphql.lookup) = {};
+    option (grafbase.graphql.argument_is) = "{ user_id: user.id }";
   }
 }
 ```
@@ -332,6 +359,11 @@ extend schema @link(url: "https://specs.grafbase.com/composite-schemas/v1", impo
 type Query {
   GetUser(input: GetUserRequest @is(field: "{ user_id: user.id }")) @lookup
 }
+```
+
+This is a shortcut for:
+```proto
+option (grafbase.graphql.argument_directives) = "@is(field: \"{ user_id: user.id }\")";
 ```
 
 ### Join fields

--- a/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
+++ b/cli/protoc-gen-grafbase-subgraph/proto/grafbase/options.proto
@@ -15,7 +15,6 @@ message Key {
 }
 
 message Lookup {
-  optional string argument_is = 1;
 }
 
 message JoinField {
@@ -59,4 +58,5 @@ extend google.protobuf.MethodOptions {
   optional bool is_mutation = 58303;
   optional string argument_directives = 58304;
   optional Lookup lookup = 58305;
+  optional string argument_is = 58306;
 }

--- a/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
@@ -123,10 +123,8 @@ fn render_method_field(
         write!(f, " {directives}")?;
     }
 
-    if let Some(lookup) = &method.lookup {
-        if let Some(argument_is) = &lookup.argument_is {
-            write!(f, " @is(field: \"{}\")", argument_is)?;
-        }
+    if let Some(argument_is) = &method.argument_is {
+        write!(f, " @is(field: \"{}\")", argument_is)?;
     }
 
     f.write_str("): ")?;

--- a/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/schema/records.rs
@@ -63,9 +63,7 @@ pub(crate) struct JoinField {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) struct Lookup {
-    pub(crate) argument_is: Option<String>,
-}
+pub(crate) struct Lookup {}
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct ProtoField {
@@ -123,6 +121,7 @@ pub(crate) struct ProtoMethod {
     pub(crate) directives: Option<String>,
     pub(crate) argument_directives: Option<String>,
     pub(crate) lookup: Option<Lookup>,
+    pub(crate) argument_is: Option<String>,
 }
 
 impl PartialOrd for ProtoMethod {

--- a/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
+++ b/cli/protoc-gen-grafbase-subgraph/src/translate_schema/options.rs
@@ -20,3 +20,4 @@ pub(super) const IS_QUERY: u32 = 58302;
 pub(super) const IS_MUTATION: u32 = 58303;
 pub(super) const ARGUMENT_DIRECTIVES: u32 = 58304;
 pub(super) const LOOKUP: u32 = 58305;
+pub(super) const ARGUMENT_IS: u32 = 58306;

--- a/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_shortcuts.proto
+++ b/cli/protoc-gen-grafbase-subgraph/tests/testcases/composite_schemas_shortcuts.proto
@@ -109,7 +109,8 @@ service UserService {
 
   // Test lookup directive
   rpc GetUser (GetUserRequest) returns (User) {
-    option (grafbase.graphql.lookup) = { argument_is: "{ user_id: user.id }" };
+    option (grafbase.graphql.lookup) = {};
+    option (grafbase.graphql.argument_is) = "{ user_id: user.id }";
   }
 
   // Regular query without lookup
@@ -121,7 +122,8 @@ service ProductService {
 
   // Another lookup example with argument_is
   rpc GetProduct (GetProductRequest) returns (Product) {
-    option (grafbase.graphql.lookup) = { argument_is: "{ product_id: product.id }" };
+    option (grafbase.graphql.lookup) = {};
+    option (grafbase.graphql.argument_is) = "{ product_id: product.id }";
   }
 
   // Lookup without argument_is - should not generate @is


### PR DESCRIPTION
`argument_is` is a field on the `lookup` option, but this is not really intuitive. So let's make it a standalone option instead.

closes GB-9522