### PR TITLE
protoc-gen-grafbase-subgraph: release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "protoc-gen-grafbase-subgraph"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "engine-field-selection-map",

--- a/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
+++ b/cli/protoc-gen-grafbase-subgraph/CHANGELOG.md
@@ -1,14 +1,16 @@
 ## Unreleased
 
+## 0.3.0 - 2025-08-13
+
 ### Added
 
-- **Composite schemas shortcuts** added. New protobuf options for simplified composite schemas directives:
-  - `key` option generates `@key` directives on types
-  - `lookup` option generates `@lookup` directive on RPC methods
-  - `argument_is` option on RPC methods generates `@is` directive on the input argument - a shortcut for `grafbase.graphql.argument_directives = "@is(field: \"...\")"`
-  - `join_field` option generates fields with `@require` and `@grpcMethod` directives, with proper type resolution
-
-- **Input argument directives** added. You can now add GraphQL directives to RPC method input argument, that corresponds to the input of the RPC method, using the `argument_directives` option on methods.
+- **Multiple subgraphs support** added. Support for generating multiple GraphQL files based on service annotations:
+  - Services can now have a `subgraph_name` option that maps them to different subgraph files
+  - When any service has a `subgraph_name`, the tool automatically switches to multi-file mode
+  - Generated files are named `<subgraph_name>.graphql` instead of the default `schema.graphql`
+  - Each subgraph file only includes the services and types relevant to that specific subgraph
+  - Multiple services can map to the same subgraph
+  - Services without `subgraph_name` in multi-file mode are ignored without warning
 
 - **Proto3 optional field support** added. The generator now properly handles proto3 optional fields:
   - Non-optional scalar and enum fields in proto3 are rendered as non-nullable (`Type!`) in GraphQL output types
@@ -17,7 +19,15 @@
   - Input types remain nullable for all fields
   - The generator now declares support for `FEATURE_PROTO3_OPTIONAL` to work with proto3 files containing optional fields
 
-- **Composite schema entity references with @derive** added. You can now create federation-style entity references using the `derive_field` option on messages:
+- **Composite schemas shortcuts** added. New protobuf options for simplified composite schemas directives:
+  - `grafbase.graphql.key` option generates `@key` directives on types
+  - `grafbase.graphql.lookup` option generates `@lookup` directive on RPC methods
+  - `grafbase.graphql.argument_is` option on RPC methods generates `@is` directive on the input argument - a shortcut for `grafbase.graphql.argument_directives = "@is(field: \"...\")"`
+  - `grafbase.graphql.join_field` option generates fields with `@require` and `@grpcMethod` directives, with proper type resolution
+
+- **Input argument directives** added. You can now add GraphQL directives to RPC method input argument, that corresponds to the input of the RPC method, using the `grafbase.graphql.argument_directives` option on methods.
+
+- **Composite schema entity references with @derive** added. You can now create federation-style entity references using the `grafbase.graphql.derive_field` option on messages:
   - Use `option (grafbase.graphql.derive_field) = {entity: "User", is: "{ id: user_id }"};` on fields
   - Automatically generates reference fields with `@derive` and `@is` directives
   - Creates stub entity types with `@key` directives if the type is not already defined
@@ -25,21 +35,11 @@
   - The `@is` directive uses the value from the `is` parameter directly
   - Enables cross-subgraph entity references in federated schemas
 
-- **Input argument directives support** added. You can now add GraphQL directives to RPC method input arguments using the `argument_directives` option:
+- **Input argument directives support** added. You can now add GraphQL directives to RPC method input arguments using the `grafbase.graphql.argument_directives` option:
   - Use `option (grafbase.graphql.argument_directives) = "@constraint(minLength: 1)";` in method options
   - Supports multiple directives in a single string, separated by spaces
   - Works with both Query and Mutation fields
   - Can be combined with existing method directives
-
-- **Multiple subgraphs support** added. Support for generating multiple GraphQL files based on service annotations:
-
-  - Services can now have a `subgraph_name` option that maps them to different subgraph files
-  - When any service has a `subgraph_name`, the tool automatically switches to multi-file mode
-  - Generated files are named `<subgraph_name>.graphql` instead of the default `schema.graphql`
-  - Each subgraph file only includes the services and types relevant to that specific subgraph
-  - Multiple services can map to the same subgraph
-  - Subgraph names must match the pattern `[a-zA-Z][a-zA-Z0-9-]*`
-  - Services without `subgraph_name` in multi-file mode are ignored without warning
 
 ### Fixed
 

--- a/cli/protoc-gen-grafbase-subgraph/Cargo.toml
+++ b/cli/protoc-gen-grafbase-subgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protoc-gen-grafbase-subgraph"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
### Added

- **Multiple subgraphs support** added. Support for generating multiple GraphQL files based on service annotations:
  - Services can now have a `subgraph_name` option that maps them to different subgraph files
  - When any service has a `subgraph_name`, the tool automatically switches to multi-file mode
  - Generated files are named `<subgraph_name>.graphql` instead of the default `schema.graphql`
  - Each subgraph file only includes the services and types relevant to that specific subgraph
  - Multiple services can map to the same subgraph
  - Services without `subgraph_name` in multi-file mode are ignored without warning

- **Proto3 optional field support** added. The generator now properly handles proto3 optional fields:
  - Non-optional scalar and enum fields in proto3 are rendered as non-nullable (`Type!`) in GraphQL output types
  - Optional scalar and enum fields are rendered as nullable (`Type`) in GraphQL output types
  - Message type fields are always nullable regardless of the optional flag
  - Input types remain nullable for all fields
  - The generator now declares support for `FEATURE_PROTO3_OPTIONAL` to work with proto3 files containing optional fields

- **Composite schemas shortcuts** added. New protobuf options for simplified composite schemas directives:
  - `grafbase.graphql.key` option generates `@key` directives on types
  - `grafbase.graphql.lookup` option generates `@lookup` directive on RPC methods
  - `grafbase.graphql.argument_is` option on RPC methods generates `@is` directive on the input argument - a shortcut for `grafbase.graphql.argument_directives = "@is(field: \"...\")"`
  - `grafbase.graphql.join_field` option generates fields with `@require` and `@grpcMethod` directives, with proper type resolution

- **Input argument directives** added. You can now add GraphQL directives to RPC method input argument, that corresponds to the input of the RPC method, using the `grafbase.graphql.argument_directives` option on methods.

- **Composite schema entity references with @derive** added. You can now create federation-style entity references using the `grafbase.graphql.derive_field` option on messages:
  - Use `option (grafbase.graphql.derive_field) = {entity: "User", is: "{ id: user_id }"};` on fields
  - Automatically generates reference fields with `@derive` and `@is` directives
  - Creates stub entity types with `@key` directives if the type is not already defined
  - Supports custom relation field names with the `name` parameter
  - The `@is` directive uses the value from the `is` parameter directly
  - Enables cross-subgraph entity references in federated schemas

- **Input argument directives support** added. You can now add GraphQL directives to RPC method input arguments using the `grafbase.graphql.argument_directives` option:
  - Use `option (grafbase.graphql.argument_directives) = "@constraint(minLength: 1)";` in method options
  - Supports multiple directives in a single string, separated by spaces
  - Works with both Query and Mutation fields
  - Can be combined with existing method directives

### Fixed

- In some scenarios, the plugin would panic because packages were not provided in alphabetical order. This is fixed. (https://github.com/grafbase/extensions/pull/144)



closes GB-9518