### PR TITLE
Improve text-matrix command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "argh"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ff18325c8a36b82f992e533ece1ec9f9a9db446bd1c14d4f936bac88fcd240"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+ "rust-fuzzy-search",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b2b83a50d329d5d8ccc620f5c7064028828538bdf5646acd60dc1f767803"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a464143cc82dedcdc3928737445362466b7674b5db4e2eb8e869846d6d84f4f6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ariadne"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,6 +5744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-fuzzy-search"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
+
+[[package]]
 name = "rust_decimal"
 version = "1.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7028,6 +7066,7 @@ name = "test-matrix"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argh",
  "duct 0.13.7",
  "serde",
  "toml 0.8.23",

--- a/test-matrix/Cargo.toml
+++ b/test-matrix/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.97"
+argh = "0.1.12"
 duct = "0.13.7"
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.20"

--- a/test-matrix/src/main.rs
+++ b/test-matrix/src/main.rs
@@ -1,48 +1,158 @@
+use std::collections::HashSet;
 use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use argh::FromArgs;
 
 mod cargo_toml;
 
-fn main() -> anyhow::Result<()> {
-    let mut found_extensions = false;
-    let mut test_arguments = vec!["nextest".to_string(), "run".to_string(), "--profile=ci".to_string()];
+#[derive(FromArgs)]
+/// Test matrix runner for Grafbase extensions
+struct Args {
+    /// skip specific extensions by name (comma-delimited list)
+    #[argh(option)]
+    skip: Option<String>,
 
-    for entry in fs::read_dir("./extensions")? {
-        let Ok(entry) = entry else {
-            continue;
-        };
+    /// run in verbose mode
+    #[argh(switch, short = 'v')]
+    verbose: bool,
 
+    /// number of test threads to use (passed to nextest)
+    #[argh(option, short = 'j')]
+    test_threads: Option<usize>,
+}
+
+fn main() -> Result<()> {
+    let args: Args = argh::from_env();
+    let skip_extensions: HashSet<String> = args
+        .skip
+        .map(|s| s.split(',').map(|ext| ext.trim().to_string()).collect())
+        .unwrap_or_default();
+
+    if args.verbose {
+        eprintln!("Test matrix runner started");
+        if !skip_extensions.is_empty() {
+            eprintln!(
+                "Skipping extensions: {}",
+                skip_extensions.iter().cloned().collect::<Vec<_>>().join(", ")
+            );
+        }
+    }
+
+    let extensions_dir = Path::new("./extensions");
+    let extensions = discover_extensions(extensions_dir, &skip_extensions)?;
+
+    if extensions.is_empty() {
+        println!("No extensions found to build and test.");
+        return Ok(());
+    }
+
+    println!("Found {} extension(s) to process", extensions.len());
+
+    for extension in &extensions {
+        build_extension(extension, args.verbose)?;
+    }
+
+    run_tests(&extensions, args.verbose, args.test_threads)?;
+
+    println!("\n✓ All done!");
+    Ok(())
+}
+
+struct Extension {
+    name: String,
+    path: PathBuf,
+}
+
+fn discover_extensions(extensions_dir: &Path, skip_set: &HashSet<String>) -> Result<Vec<Extension>> {
+    let mut extensions = Vec::new();
+
+    let entries = fs::read_dir(extensions_dir).with_context(|| {
+        format!(
+            "Failed to read extensions directory: {path}",
+            path = extensions_dir.display()
+        )
+    })?;
+
+    for entry in entries {
+        let entry = entry.context("Failed to read directory entry")?;
         let path = entry.path();
 
         if !path.is_dir() {
             continue;
         }
 
-        let Ok(cargo_toml) = fs::read_to_string(path.join("Cargo.toml")) else {
+        let cargo_toml_path = path.join("Cargo.toml");
+        if !cargo_toml_path.exists() {
             continue;
-        };
+        }
 
-        let cargo_toml = cargo_toml::parse(&cargo_toml)?;
+        let cargo_toml_content = fs::read_to_string(&cargo_toml_path)
+            .with_context(|| format!("Failed to read {path}", path = cargo_toml_path.display()))?;
 
-        println!("\n** {} **", cargo_toml.name());
-        duct::cmd("grafbase", ["extension", "build", "--scratch-dir", "../../target"])
-            .dir(path)
-            .run()
-            .map_err(|e| anyhow::anyhow!("Failed to build extension (is grafbase in your path?): {}", e))?;
+        let cargo_toml = cargo_toml::parse(&cargo_toml_content)
+            .with_context(|| format!("Failed to parse {path}", path = cargo_toml_path.display()))?;
 
-        test_arguments.push("-p".to_string());
-        test_arguments.push(cargo_toml.name().to_string());
+        let name = cargo_toml.name().to_string();
 
-        found_extensions = true;
+        if skip_set.contains(&name) {
+            eprintln!("  Skipping extension: {name}");
+            continue;
+        }
+
+        extensions.push(Extension { name, path });
     }
 
-    if !found_extensions {
+    Ok(extensions)
+}
+
+fn build_extension(extension: &Extension, verbose: bool) -> Result<()> {
+    println!("** Building {name} **", name = extension.name);
+
+    let mut cmd = duct::cmd("grafbase", ["extension", "build", "--scratch-dir", "../../target"]).dir(&extension.path);
+
+    if !verbose {
+        cmd = cmd.stdout_null().stderr_null();
+    }
+
+    cmd.run().with_context(|| {
+        format!(
+            "Failed to build extension {name} (is grafbase in your path?)",
+            name = extension.name
+        )
+    })?;
+
+    Ok(())
+}
+
+fn run_tests(extensions: &[Extension], verbose: bool, test_threads: Option<usize>) -> Result<()> {
+    if extensions.is_empty() {
+        println!("No extensions to test.");
         return Ok(());
     }
 
-    println!("\n** Running tests **");
-    duct::cmd("cargo", &test_arguments)
-        .env("PREBUILT_EXTENSION", "1")
-        .run()?;
+    println!("\n** Running tests for {} extension(s) **", extensions.len());
+
+    let mut test_arguments = vec!["nextest".to_string(), "run".to_string(), "--profile=ci".to_string()];
+
+    if let Some(threads) = test_threads {
+        test_arguments.push("-j".to_string());
+        test_arguments.push(threads.to_string());
+    }
+
+    for extension in extensions {
+        test_arguments.push("-p".to_string());
+        test_arguments.push(extension.name.clone());
+    }
+
+    let mut cmd = duct::cmd("cargo", &test_arguments).env("PREBUILT_EXTENSION", "1");
+
+    if !verbose {
+        cmd = cmd.stdout_null();
+    }
+
+    cmd.run().context("Failed to run tests")?;
 
     Ok(())
 }


### PR DESCRIPTION
Add `--skip` & `-v` arguments to the command line and some "cleanup" by Claude. The skip is useful in the grafbase repo so we can skip tests that use unsupported features (such as native JWT)